### PR TITLE
[wip] Remove OPA endpoint setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,7 +351,7 @@ docker run -v './path/to/config.yml:/usr/src/app/config.yml' -p '50051:50051' 3s
 
 ### Deploy on a Kubernetes cluster
 
-A set of YAMLs exemplifying Authorino deployed to Kubernetes with an OPA PDP sidecar can be found [here](examples/openshift). We recommend storing Authorino's `config.yml` in a `ConfigMap` ([example](examples/openshift/configmap.yaml)). Follow by creating Authorino's `Deployment` and `Service`.
+A set of YAMLs exemplifying Authorino deployed to Kubernetes can be found [here](examples/openshift). We recommend storing Authorino's `config.yml` in a `ConfigMap` ([example](examples/openshift/configmap.yaml)). Follow by creating Authorino's `Deployment` and `Service`.
 
 Usually the entire order of deployment goes as follows:
 1. Upstream API(s)

--- a/examples/config.yml
+++ b/examples/config.yml
@@ -64,7 +64,6 @@ echo-api:3000:
   authorization:
     - opa:
         uuid: 8fa79d93-0f93-4e23-8c2a-666be266cad1
-        endpoint: 'http://opa:8181'
         rego: |
           allow {
             http_request.method == "GET"


### PR DESCRIPTION
The option is no longer needed since OPA was integrated as a Go module instead of an external HTTP service.
Reference to OPA as a sidecard container in Kubernetes deployment also fixed.