### PR TITLE
Specifies missing secrets perms for kubebuilder codegen

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -32,5 +32,5 @@ rules:
   - secrets
   verbs:
   - get
-  - watch
   - list
+  - watch

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -48,6 +48,7 @@ type ServiceReconciler struct {
 
 // +kubebuilder:rbac:groups=config.authorino.3scale.net,resources=services,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=config.authorino.3scale.net,resources=services/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;
 
 func (r *ServiceReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()


### PR DESCRIPTION
By adding those perms we ensure that the code generation will recreate the role.yaml file properly