### PR TITLE
Concurrent authcontext calls

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/3scale-labs/authorino/pkg/config"
 	authorinoService "github.com/3scale-labs/authorino/pkg/config"
 	authorinoAuthorization "github.com/3scale-labs/authorino/pkg/config/authorization"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 	authorinoIdentity "github.com/3scale-labs/authorino/pkg/config/identity"
 	authorinoMetadata "github.com/3scale-labs/authorino/pkg/config/metadata"
 	"github.com/go-logr/logr"
@@ -98,6 +99,7 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 	service *configv1beta1.Service) (map[string]authorinoService.APIConfig, error) {
 
 	identityConfigs := make([]config.IdentityConfig, 0)
+	interfacedIdentityConfigs := make([]common.AuthConfigEvaluator, 0)
 
 	for _, identity := range service.Spec.Identity {
 
@@ -118,9 +120,11 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 		}
 
 		identityConfigs = append(identityConfigs, translatedIdentity)
+		interfacedIdentityConfigs = append(interfacedIdentityConfigs, &translatedIdentity)
 	}
 
 	metadataConfigs := make([]config.MetadataConfig, 0)
+	interfacedMetadataConfigs := make([]common.AuthConfigEvaluator, 0)
 
 	for _, metadata := range service.Spec.Metadata {
 
@@ -181,9 +185,11 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 		}
 
 		metadataConfigs = append(metadataConfigs, translatedMetadata)
+		interfacedMetadataConfigs = append(interfacedMetadataConfigs, &translatedMetadata)
 	}
 
 	authorizationConfigs := make([]config.AuthorizationConfig, 0)
+	interfacedAuthorizationConfigs := make([]common.AuthConfigEvaluator, 0)
 
 	for _, authorization := range service.Spec.Authorization {
 
@@ -235,16 +241,16 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 		}
 
 		authorizationConfigs = append(authorizationConfigs, translatedAuthorization)
-
+		interfacedAuthorizationConfigs = append(interfacedAuthorizationConfigs, &translatedAuthorization)
 	}
 
 	config := make(map[string]authorinoService.APIConfig, 0)
 
 	authorinoService := authorinoService.APIConfig{
 		Enabled:              true,
-		IdentityConfigs:      identityConfigs,
-		MetadataConfigs:      metadataConfigs,
-		AuthorizationConfigs: authorizationConfigs,
+		IdentityConfigs:      interfacedIdentityConfigs,
+		MetadataConfigs:      interfacedMetadataConfigs,
+		AuthorizationConfigs: interfacedAuthorizationConfigs,
 	}
 
 	for _, host := range service.Spec.Hosts {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/open-policy-agent/opa v0.25.2
 	github.com/pquerna/cachecontrol v0.0.0-20201205024021-ac21108117ac // indirect
 	golang.org/x/net v0.0.0-20200927032502-5d4f70055728
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	google.golang.org/grpc v1.26.0
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -555,7 +555,10 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a h1:DcqTD9SDLc+1P/r1EmRBwnVsrOwW+kk2vWf9n+1sGhs=
+golang.org/x/sync v0.0.0-20201207232520-09787c993a3a/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180830151530-49385e6e1522/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -7,18 +7,23 @@ import (
 	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
+var (
+	// AuthorizationEvaluator represents the authorizationConfig struct implementing its Call method
+	AuthorizationEvaluator common.AuthConfigEvaluator
+)
+
 type AuthorizationConfig struct {
 	OPA *authorization.OPA       `yaml:"opa"`
 	JWT *authorization.JWTClaims `yaml:"jwt"`
 }
 
-func (self *AuthorizationConfig) Call(ctx common.AuthContext) (interface{}, error) {
+func (config *AuthorizationConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
-	case self.OPA != nil:
-		return self.OPA.Call(ctx)
-	case self.JWT != nil:
-		return self.JWT.Call(ctx)
+	case config.OPA != nil:
+		return config.OPA.Call(ctx)
+	case config.JWT != nil:
+		return config.JWT.Call(ctx)
 	default:
-		return false, fmt.Errorf("Invalid authorization configs")
+		return false, fmt.Errorf("invalid authorization configs")
 	}
 }

--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -12,7 +12,7 @@ type AuthorizationConfig struct {
 	JWT *authorization.JWTClaims `yaml:"jwt"`
 }
 
-func (self *AuthorizationConfig) Call(ctx common.AuthContext) (bool, error) {
+func (self *AuthorizationConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
 	case self.OPA != nil:
 		return self.OPA.Call(ctx)

--- a/pkg/config/common/auth_context.go
+++ b/pkg/config/common/auth_context.go
@@ -15,3 +15,8 @@ type AuthContext interface {
 	FindIdentityByName(name string) (interface{}, error)
 	AuthorizationToken() (string, error)
 }
+
+// AuthConfigEvaluator interface represents the configuration pieces of Identity, Metadata and Authorization
+type AuthConfigEvaluator interface {
+	Call(AuthContext) (interface{}, error)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,11 +1,13 @@
 package config
 
+import "github.com/3scale-labs/authorino/pkg/config/common"
+
 // APIConfig holds the configuration of each protected API
 type APIConfig struct {
-	Enabled              bool                  `yaml:"enabled,omitempty"`
-	IdentityConfigs      []IdentityConfig      `yaml:"identity,omitempty"`
-	MetadataConfigs      []MetadataConfig      `yaml:"metadata,omitempty"`
-	AuthorizationConfigs []AuthorizationConfig `yaml:"authorization,omitempty"`
+	Enabled              bool                         `yaml:"enabled,omitempty"`
+	IdentityConfigs      []common.AuthConfigEvaluator `yaml:"identity,omitempty"`
+	MetadataConfigs      []common.AuthConfigEvaluator `yaml:"metadata,omitempty"`
+	AuthorizationConfigs []common.AuthConfigEvaluator `yaml:"authorization,omitempty"`
 }
 
 func (self *APIConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -7,6 +7,11 @@ import (
 	"github.com/3scale-labs/authorino/pkg/config/identity"
 )
 
+var (
+	// IdentityEvaluator represents the identityConfig struct implementing its Call method
+	IdentityEvaluator common.AuthConfigEvaluator
+)
+
 type IdentityConfig struct {
 	OIDC   *identity.OIDC   `yaml:"oidc,omitempty"`
 	MTLS   *identity.MTLS   `yaml:"mtls,omitempty"`
@@ -14,17 +19,22 @@ type IdentityConfig struct {
 	APIKey *identity.APIKey `yaml:"api_key,omitempty"`
 }
 
-func (self *IdentityConfig) Call(ctx common.AuthContext) (interface{}, error) {
+func init() {
+	IdentityEvaluator = &IdentityConfig{}
+}
+
+// Call method will execute the specific Identity implementation's method
+func (config *IdentityConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
-	case self.OIDC != nil:
-		return self.OIDC.Call(ctx)
-	case self.MTLS != nil:
-		return self.MTLS.Call(ctx)
-	case self.HMAC != nil:
-		return self.HMAC.Call(ctx)
-	case self.APIKey != nil:
-		return self.APIKey.Call(ctx)
+	case config.OIDC != nil:
+		return config.OIDC.Call(ctx)
+	case config.MTLS != nil:
+		return config.MTLS.Call(ctx)
+	case config.HMAC != nil:
+		return config.HMAC.Call(ctx)
+	case config.APIKey != nil:
+		return config.APIKey.Call(ctx)
 	default:
-		return "", fmt.Errorf("Invalid identity config")
+		return "", fmt.Errorf("invalid identity config")
 	}
 }

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -7,30 +7,39 @@ import (
 	"github.com/3scale-labs/authorino/pkg/config/metadata"
 )
 
+var (
+	// MetadataEvaluator represents the metadataStruct implementing its Call method
+	MetadataEvaluator common.AuthConfigEvaluator
+)
+
 type MetadataConfig struct {
 	UserInfo *metadata.UserInfo `yaml:"userinfo,omitempty"`
 	UMA      *metadata.UMA      `yaml:"uma,omitempty"`
 }
 
-func (self *MetadataConfig) Call(ctx common.AuthContext) (interface{}, error) {
-	t, _ := self.GetType()
+func init() {
+	MetadataEvaluator = &MetadataConfig{}
+}
+
+func (config *MetadataConfig) Call(ctx common.AuthContext) (interface{}, error) {
+	t, _ := config.GetType()
 	switch t {
 	case "userinfo":
-		return self.UserInfo.Call(ctx)
+		return config.UserInfo.Call(ctx)
 	case "uma":
-		return self.UMA.Call(ctx)
+		return config.UMA.Call(ctx)
 	default:
-		return "", fmt.Errorf("Invalid metadata config")
+		return "", fmt.Errorf("invalid metadata config")
 	}
 }
 
-func (self *MetadataConfig) GetType() (string, error) {
+func (config *MetadataConfig) GetType() (string, error) {
 	switch {
-	case self.UserInfo != nil:
+	case config.UserInfo != nil:
 		return "userinfo", nil
-	case self.UMA != nil:
+	case config.UMA != nil:
 		return "uma", nil
 	default:
-		return "", fmt.Errorf("Invalid metadata config")
+		return "", fmt.Errorf("invalid metadata config")
 	}
 }

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -38,11 +38,7 @@ func (self *AuthService) Check(ctx context.Context, req *auth.CheckRequest) (*au
 		return self.deniedResponse(rpc.NOT_FOUND, "Service not found"), nil
 	}
 
-	authContext := AuthContext{
-		ParentContext: &ctx,
-		Request:       req,
-		API:           &apiConfig,
-	}
+	authContext := NewAuthContext(ctx, req, apiConfig)
 
 	err = authContext.Evaluate()
 	if err != nil {

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"encoding/json"
-	"log"
 
 	"github.com/3scale-labs/authorino/pkg/cache"
 	"golang.org/x/net/context"
@@ -12,6 +11,11 @@ import (
 	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
 	"github.com/gogo/googleapis/google/rpc"
 	rpcstatus "google.golang.org/genproto/googleapis/rpc/status"
+	ctrl "sigs.k8s.io/controller-runtime"
+)
+
+var (
+	authServiceLog = ctrl.Log.WithName("Authorino").WithName("AuthService")
 )
 
 // AuthService is the server API for the authorization service.
@@ -26,7 +30,7 @@ func (self *AuthService) Check(ctx context.Context, req *auth.CheckRequest) (*au
 	if err != nil {
 		return self.deniedResponse(rpc.FAILED_PRECONDITION, "Invalid request"), nil
 	}
-	log.Println("[AuthService] Check()\n", string(reqJSON))
+	authServiceLog.Info("Check()", "reqJSON", string(reqJSON))
 
 	// service config
 	host := req.Attributes.Request.Http.Host

--- a/pkg/service/auth_context.go
+++ b/pkg/service/auth_context.go
@@ -33,6 +33,19 @@ type AuthObjectConfig interface {
 
 type configCallback = func(config AuthObjectConfig, obj interface{})
 
+func NewAuthContext(parentCtx context.Context, req *auth.CheckRequest, apiConfig config.APIConfig) AuthContext {
+
+	return AuthContext{
+		ParentContext: &parentCtx,
+		Request:       req,
+		API:           &apiConfig,
+		Identity:      make(map[*config.IdentityConfig]interface{}),
+		Metadata:      make(map[*config.MetadataConfig]interface{}),
+		Authorization: make(map[*config.AuthorizationConfig]interface{}),
+	}
+
+}
+
 func (authContext *AuthContext) getAuthObject(ctx context.Context, objConfig AuthObjectConfig, cb configCallback) error {
 	select {
 	case <-ctx.Done():

--- a/pkg/service/auth_context.go
+++ b/pkg/service/auth_context.go
@@ -66,16 +66,14 @@ func (self *AuthContext) Evaluate() error {
 
 	// policy enforcement (authorization)
 	for _, config := range self.API.AuthorizationConfigs {
-		go func() error {
-			if ret, err := config.Call(self); err != nil {
-				return err
-			} else {
-				self.Authorization[&config] = ret
-				metadataCh <- true
-				return nil
+		var idAuthObjCfg AuthObjectConfig = &config
+		go func() {
+			if authObj, err := self.getAuthObject(idAuthObjCfg, identityCh); err == nil {
+				self.Authorization[&config] = authObj
 			}
 		}()
 	}
+
 	<-authCh
 
 	return nil

--- a/pkg/service/auth_context.go
+++ b/pkg/service/auth_context.go
@@ -30,12 +30,10 @@ type AuthObjectConfig interface {
 	Call(ctx internal.AuthContext) (interface{}, error)
 }
 
-func (authContext *AuthContext) getAuthObject(authObjConfig AuthObjectConfig, wg *sync.WaitGroup) (interface{}, error) {
+func (authContext *AuthContext) getAuthObject(authObjConfig AuthObjectConfig) (interface{}, error) {
 	if ret, err := authObjConfig.Call(authContext); err != nil {
-		wg.Done()
 		return nil, err
 	} else {
-		wg.Done()
 		return ret, nil
 	}
 }
@@ -48,7 +46,8 @@ func (authContext *AuthContext) GetIDObject() error {
 		wg.Add(1)
 		var authObjCfg AuthObjectConfig = &config
 		go func() {
-			if authObj, err := authContext.getAuthObject(authObjCfg, &wg); err != nil {
+			defer wg.Done()
+			if authObj, err := authContext.getAuthObject(authObjCfg); err != nil {
 				authObjError = err
 				fmt.Errorf("Invalid identity config", err)
 			} else {
@@ -68,7 +67,8 @@ func (authContext *AuthContext) GetMDObject() error {
 		var authObjCfg AuthObjectConfig = &config
 		wg.Add(1)
 		go func() {
-			if authObj, err := authContext.getAuthObject(authObjCfg, &wg); err != nil {
+			defer wg.Done()
+			if authObj, err := authContext.getAuthObject(authObjCfg); err != nil {
 				authObjError = err
 				fmt.Errorf("Invalid metadata config", err)
 			} else {
@@ -88,7 +88,8 @@ func (authContext *AuthContext) GetAuthObject() error {
 		var authObjCfg AuthObjectConfig = &config
 		wg.Add(1)
 		go func() {
-			if authObj, err := authContext.getAuthObject(authObjCfg, &wg); err != nil {
+			defer wg.Done()
+			if authObj, err := authContext.getAuthObject(authObjCfg); err != nil {
 				authObjError = err
 				fmt.Errorf("Invalid authentication config", err)
 			} else {

--- a/pkg/service/auth_context.go
+++ b/pkg/service/auth_context.go
@@ -6,8 +6,8 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/3scale/authorino/pkg/config"
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"golang.org/x/net/context"
@@ -28,7 +28,7 @@ type AuthContext struct {
 
 // AuthObjectConfig provides an interface for APIConfig objects that implements a Call method
 type AuthObjectConfig interface {
-	Call(ctx internal.AuthContext) (interface{}, error)
+	Call(ctx common.AuthContext) (interface{}, error)
 }
 
 type configCallback = func(config AuthObjectConfig, obj interface{})

--- a/vendor/golang.org/x/sync/AUTHORS
+++ b/vendor/golang.org/x/sync/AUTHORS
@@ -1,0 +1,3 @@
+# This source code refers to The Go Authors for copyright purposes.
+# The master list of authors is in the main Go distribution,
+# visible at http://tip.golang.org/AUTHORS.

--- a/vendor/golang.org/x/sync/CONTRIBUTORS
+++ b/vendor/golang.org/x/sync/CONTRIBUTORS
@@ -1,0 +1,3 @@
+# This source code was written by the Go contributors.
+# The master list of contributors is in the main Go distribution,
+# visible at http://tip.golang.org/CONTRIBUTORS.

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,66 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+package errgroup
+
+import (
+	"context"
+	"sync"
+)
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid and does not cancel on error.
+type Group struct {
+	cancel func()
+
+	wg sync.WaitGroup
+
+	errOnce sync.Once
+	err     error
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel()
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+//
+// The first call to return a non-nil error cancels the group; its error will be
+// returned by Wait.
+func (g *Group) Go(f func() error) {
+	g.wg.Add(1)
+
+	go func() {
+		defer g.wg.Done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel()
+				}
+			})
+		}
+	}()
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -250,6 +250,9 @@ golang.org/x/oauth2/google
 golang.org/x/oauth2/internal
 golang.org/x/oauth2/jws
 golang.org/x/oauth2/jwt
+# golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
+## explicit
+golang.org/x/sync/errgroup
 # golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 golang.org/x/sys/internal/unsafeheader
 golang.org/x/sys/unix


### PR DESCRIPTION
This PR implements a concurrent way of getting Auth objects, instead of getting them in sequential order.

Fixes https://github.com/3scale-labs/authorino/issues/27

Notes:
No tests. A following refactor of the different auth config objects is needed first, in order to avoid converting this into massive refactor PR.