### PR TITLE
enhancement concurrent authcontext calls

### DIFF
--- a/pkg/common/common.go
+++ b/pkg/common/common.go
@@ -1,8 +1,8 @@
-package internal
+package common
 
 import (
-	"golang.org/x/net/context"
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	"golang.org/x/net/context"
 )
 
 type AuthContext interface {

--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -4,8 +4,8 @@ import (
 	"fmt"
 	"reflect"
 
+	"github.com/3scale/authorino/pkg/common"
 	"github.com/3scale/authorino/pkg/config/authorization"
-	"github.com/3scale/authorino/pkg/config/internal"
 )
 
 type AuthorizationConfig struct {
@@ -13,7 +13,7 @@ type AuthorizationConfig struct {
 	JWT authorization.JWTClaims `yaml:"jwt"`
 }
 
-func (self *AuthorizationConfig) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *AuthorizationConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
 	case self.OPA != authorization.OPA{}:
 		return self.OPA.Call(ctx)

--- a/pkg/config/authorization/jwt.go
+++ b/pkg/config/authorization/jwt.go
@@ -1,26 +1,30 @@
 package authorization
 
 import (
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 )
 
 type JWTClaims struct {
-	Enabled bool `yaml:"enabled,omitempty"`
-	Match map[string]map[string]string `yaml:"match"` // TODO: implement
-	Claims map[string]string `yaml:"claims"` // TODO: implement
+	Enabled bool                         `yaml:"enabled,omitempty"`
+	Match   map[string]map[string]string `yaml:"match"`  // TODO: implement
+	Claims  map[string]string            `yaml:"claims"` // TODO: implement
 }
 
 func (self *JWTClaims) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Alias JWTClaims
-	a := Alias{ Enabled: true }
+	a := Alias{Enabled: true}
 	err := unmarshal(&a)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	*self = JWTClaims(a)
 	return nil
 }
 
-func (self *JWTClaims) Call(ctx internal.AuthContext) (bool, error)  {
-	if !self.Enabled { return true, nil }
+func (self *JWTClaims) Call(ctx common.AuthContext) (bool, error) {
+	if !self.Enabled {
+		return true, nil
+	}
 
 	return true, nil // TODO: Implement
 }

--- a/pkg/config/authorization/opa.go
+++ b/pkg/config/authorization/opa.go
@@ -1,33 +1,37 @@
 package authorization
 
 import (
-	"fmt"
 	"context"
-	"log"
 	"encoding/json"
+	"fmt"
+	"log"
 
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/open-policy-agent/opa/rego"
 )
 
 type OPA struct {
-	Enabled bool `yaml:"enabled,omitempty"`
-	UUID string `yaml:"uuid"`
-	Rego string `yaml:"rego"`
+	Enabled    bool   `yaml:"enabled,omitempty"`
+	UUID       string `yaml:"uuid"`
+	Rego       string `yaml:"rego"`
 	opaContext context.Context
-	policy *rego.PreparedEvalQuery
+	policy     *rego.PreparedEvalQuery
 }
 
 func (self *OPA) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	type Alias OPA
-	a := Alias{ Enabled: true }
+	a := Alias{Enabled: true}
 	err := unmarshal(&a)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	*self = OPA(a)
 	err = self.prepare()
-	if err != nil { return fmt.Errorf("opa: failed to prepare inline Rego policy %v", self.policyName())	}
+	if err != nil {
+		return fmt.Errorf("opa: failed to prepare inline Rego policy %v", self.policyName())
+	}
 	return nil
 }
 
@@ -47,9 +51,11 @@ func (self *OPA) prepare() error {
 	self.opaContext = context.TODO()
 
 	regoQuery := rego.Query("allowed = data." + self.policyName() + ".allow")
-	regoModule := rego.Module(self.UUID + ".rego", regoPolicy)
+	regoModule := rego.Module(self.UUID+".rego", regoPolicy)
 	p, err := rego.New(regoQuery, regoModule).PrepareForEval(self.opaContext)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 
 	self.policy = &p
 
@@ -69,12 +75,16 @@ type OPAInput struct {
 
 func (self *OPAInput) ToJSON() ([]byte, error) {
 	res, err := json.Marshal(&self)
-  if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return res, nil
 }
 
-func (self *OPA) Call(ctx internal.AuthContext) (bool, error)  {
-	if !self.Enabled { return true, nil }
+func (self *OPA) Call(ctx common.AuthContext) (bool, error) {
+	if !self.Enabled {
+		return true, nil
+	}
 
 	contextData := make(map[string]interface{})
 	contextData["identity"] = ctx.GetIdentity()
@@ -86,13 +96,15 @@ func (self *OPA) Call(ctx internal.AuthContext) (bool, error)  {
 	}
 
 	inputJSON, err := input.ToJSON()
-	if err != nil { return false, err }
+	if err != nil {
+		return false, err
+	}
 	log.Printf("[OPA] input: %v", string(inputJSON))
 
 	results, err := self.policy.Eval(self.opaContext, rego.EvalInput(input))
 
 	if err != nil {
-    return false, err
+		return false, err
 	} else if len(results) == 0 {
 		return false, fmt.Errorf("opa: invalid response for policy %v", self.policyName())
 	} else if allowed := results[0].Bindings["allowed"].(bool); !allowed {

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -3,23 +3,28 @@ package config
 import (
 	"fmt"
 
+	"github.com/3scale/authorino/pkg/common"
 	"github.com/3scale/authorino/pkg/config/identity"
-	"github.com/3scale/authorino/pkg/config/internal"
 )
 
 type IdentityConfig struct {
-	OIDC identity.OIDC `yaml:"oidc,omitempty"`
-	MTLS identity.MTLS `yaml:"mtls,omitempty"`
-	HMAC identity.HMAC `yaml:"hmac,omitempty"`
+	OIDC   identity.OIDC   `yaml:"oidc,omitempty"`
+	MTLS   identity.MTLS   `yaml:"mtls,omitempty"`
+	HMAC   identity.HMAC   `yaml:"hmac,omitempty"`
 	APIKey identity.APIKey `yaml:"api_key,omitempty"`
 }
 
-func (self *IdentityConfig) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *IdentityConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
-		case self.OIDC != identity.OIDC{}: return self.OIDC.Call(ctx)
-		case self.MTLS != identity.MTLS{}: return self.MTLS.Call(ctx)
-		case self.HMAC != identity.HMAC{}: return self.HMAC.Call(ctx)
-		case self.APIKey != identity.APIKey{}: return self.APIKey.Call(ctx)
-		default: return "", fmt.Errorf("Invalid identity config")
+	case self.OIDC != identity.OIDC{}:
+		return self.OIDC.Call(ctx)
+	case self.MTLS != identity.MTLS{}:
+		return self.MTLS.Call(ctx)
+	case self.HMAC != identity.HMAC{}:
+		return self.HMAC.Call(ctx)
+	case self.APIKey != identity.APIKey{}:
+		return self.APIKey.Call(ctx)
+	default:
+		return "", fmt.Errorf("Invalid identity config")
 	}
 }

--- a/pkg/config/identity/api_key.go
+++ b/pkg/config/identity/api_key.go
@@ -1,13 +1,13 @@
 package identity
 
 import (
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 )
 
 type APIKey struct {
 	SecretKey string `yaml:"secret_key"`
 }
 
-func (self *APIKey) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *APIKey) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with API key", nil // TODO: implement
 }

--- a/pkg/config/identity/hmac.go
+++ b/pkg/config/identity/hmac.go
@@ -1,13 +1,13 @@
 package identity
 
 import (
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 )
 
 type HMAC struct {
 	Secret string `yaml:"secret"`
 }
 
-func (self *HMAC) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *HMAC) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with HMAC", nil // TODO: implement
 }

--- a/pkg/config/identity/mtls.go
+++ b/pkg/config/identity/mtls.go
@@ -1,13 +1,13 @@
 package identity
 
 import (
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 )
 
 type MTLS struct {
 	PEM string `yaml:"pem"`
 }
 
-func (self *MTLS) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *MTLS) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with mTLS", nil // TODO: implement
 }

--- a/pkg/config/identity/oidc.go
+++ b/pkg/config/identity/oidc.go
@@ -3,38 +3,48 @@ package identity
 import (
 	"context"
 
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 
 	oidc "github.com/coreos/go-oidc"
 )
 
 type OIDC struct {
-	Name string `yaml:"name"`
+	Name     string `yaml:"name"`
 	Endpoint string `yaml:"endpoint"`
 }
 
-func (self *OIDC) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *OIDC) Call(ctx common.AuthContext) (interface{}, error) {
 	// extract access token
 	accessToken, err := ctx.AuthorizationToken()
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	// verify jwt
 	provider, err := self.NewProvider(ctx)
-	if err != nil { return nil, err }
-	oidcConfig := &oidc.Config{ SkipClientIDCheck: true, SkipIssuerCheck: true }
+	if err != nil {
+		return nil, err
+	}
+	oidcConfig := &oidc.Config{SkipClientIDCheck: true, SkipIssuerCheck: true}
 	verifier := provider.Verifier(oidcConfig)
 	idToken, err := verifier.Verify(context.TODO(), accessToken)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	var claims interface{}
 	err = idToken.Claims(&claims)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	return claims, nil
 }
 
-func (self *OIDC) NewProvider(ctx internal.AuthContext) (*oidc.Provider, error) {
+func (self *OIDC) NewProvider(ctx common.AuthContext) (*oidc.Provider, error) {
 	provider, err := oidc.NewProvider(context.TODO(), self.Endpoint)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	return provider, nil
 }

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -3,28 +3,34 @@ package config
 import (
 	"fmt"
 
+	"github.com/3scale/authorino/pkg/common"
 	"github.com/3scale/authorino/pkg/config/metadata"
-	"github.com/3scale/authorino/pkg/config/internal"
 )
 
 type MetadataConfig struct {
 	UserInfo metadata.UserInfo `yaml:"userinfo,omitempty"`
-	UMA metadata.UMA `yaml:"uma,omitempty"`
+	UMA      metadata.UMA      `yaml:"uma,omitempty"`
 }
 
-func (self *MetadataConfig) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *MetadataConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	t, _ := self.GetType()
 	switch t {
-		case "userinfo": return self.UserInfo.Call(ctx)
-		case "uma": return self.UMA.Call(ctx)
-		default: return "", fmt.Errorf("Invalid metadata config")
+	case "userinfo":
+		return self.UserInfo.Call(ctx)
+	case "uma":
+		return self.UMA.Call(ctx)
+	default:
+		return "", fmt.Errorf("Invalid metadata config")
 	}
 }
 
 func (self *MetadataConfig) GetType() (string, error) {
 	switch {
-		case self.UserInfo != metadata.UserInfo{}: return "userinfo", nil
-		case self.UMA != metadata.UMA{}: return "uma", nil
-		default: return "", fmt.Errorf("Invalid metadata config")
+	case self.UserInfo != metadata.UserInfo{}:
+		return "userinfo", nil
+	case self.UMA != metadata.UMA{}:
+		return "uma", nil
+	default:
+		return "", fmt.Errorf("Invalid metadata config")
 	}
 }

--- a/pkg/config/metadata/uma.go
+++ b/pkg/config/metadata/uma.go
@@ -1,35 +1,41 @@
 package metadata
 
 import (
-	"fmt"
 	"encoding/json"
-	"net/url"
-	"net/http"
-	"mime"
-	"strings"
+	"fmt"
 	"io/ioutil"
+	"mime"
+	"net/http"
+	"net/url"
+	"strings"
 
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 )
 
 type UMA struct {
-	Endpoint string `yaml:"endpoint,omitempty"`
-	ClientID string `yaml:"client_id"`
+	Endpoint     string `yaml:"endpoint,omitempty"`
+	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
 }
 
-func (self *UMA) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *UMA) Call(ctx common.AuthContext) (interface{}, error) {
 	// discover uma config
 	provider, err := self.NewProvider(ctx)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	// get the protection API token (PAT)
 	tokenURL, _ := self.clientAuthenticatedURL(provider.GetTokenURL())
-	resp, err := http.PostForm(tokenURL.String(), url.Values{ "grant_type": {"client_credentials"} })
-	if err != nil { return nil, err }
+	resp, err := http.PostForm(tokenURL.String(), url.Values{"grant_type": {"client_credentials"}})
+	if err != nil {
+		return nil, err
+	}
 	var pat PAT
 	err = unmashalJSONResponse(resp, &pat, nil)
-	if err != nil { return nil, fmt.Errorf("uma: failed to decode PAT: %v", err) }
+	if err != nil {
+		return nil, fmt.Errorf("uma: failed to decode PAT: %v", err)
+	}
 
 	// query resources by URI
 	resourceRegistrationURL, _ := url.Parse(provider.GetResourceRegistrationURL())
@@ -37,7 +43,9 @@ func (self *UMA) Call(ctx internal.AuthContext) (interface{}, error) {
 	queryResourcesURL.RawQuery = "uri=" + ctx.GetRequest().Attributes.Request.Http.GetPath()
 	var resourceIDs []string
 	err = getPATAuthenticatedJSON(queryResourcesURL.String(), pat, &resourceIDs)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	// get each resource data
 	resourceData := make([]interface{}, len(resourceIDs))
@@ -53,31 +61,39 @@ func (self *UMA) Call(ctx internal.AuthContext) (interface{}, error) {
 	return resourceData, nil
 }
 
-func (self *UMA) NewProvider(ctx internal.AuthContext) (*Provider, error) {
+func (self *UMA) NewProvider(ctx common.AuthContext) (*Provider, error) {
 	// discover uma config
 	wellKnown := strings.TrimSuffix(self.Endpoint, "/") + "/.well-known/uma2-configuration"
 	resp, err := http.Get(wellKnown)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 	var p providerJSON
 	var rawClaims []byte
 	err = unmashalJSONResponse(resp, &p, &rawClaims)
-	if err != nil { return nil, fmt.Errorf("uma: failed to decode provider discovery object: %v", err) }
+	if err != nil {
+		return nil, fmt.Errorf("uma: failed to decode provider discovery object: %v", err)
+	}
 
 	// verify same issuer
-	if p.Issuer != self.Endpoint { return nil, fmt.Errorf("uma: issuer did not match the issuer returned by provider, expected %q got %q", self.Endpoint, p.Issuer) }
+	if p.Issuer != self.Endpoint {
+		return nil, fmt.Errorf("uma: issuer did not match the issuer returned by provider, expected %q got %q", self.Endpoint, p.Issuer)
+	}
 
 	return &Provider{
-		issuer: p.Issuer,
-		tokenURL: p.TokenURL,
+		issuer:                  p.Issuer,
+		tokenURL:                p.TokenURL,
 		resourceRegistrationURL: p.ResourceRegistrationURL,
-		rawClaims: rawClaims,
+		rawClaims:               rawClaims,
 	}, nil
 }
 
 func (self *UMA) clientAuthenticatedURL(rawurl string) (*url.URL, error) {
 	parsedURL, err := url.Parse(rawurl)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	parsedURL.User = url.UserPassword(self.ClientID, self.ClientSecret)
 	return parsedURL, nil
 }
@@ -85,22 +101,26 @@ func (self *UMA) clientAuthenticatedURL(rawurl string) (*url.URL, error) {
 func getPATAuthenticatedJSON(rawurl string, pat PAT, v interface{}) error {
 	// build the request
 	req, err := http.NewRequest("GET", rawurl, nil)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "Bearer " + pat.String())
+	req.Header.Set("Authorization", "Bearer "+pat.String())
 
 	// get the response
 	client := &http.Client{}
 	resp, err := client.Do(req)
-	if err != nil { return err }
+	if err != nil {
+		return err
+	}
 	defer resp.Body.Close()
 
 	return unmashalJSONResponse(resp, &v, nil)
 }
 
 type Provider struct {
-	issuer string
-	tokenURL string
+	issuer                  string
+	tokenURL                string
 	resourceRegistrationURL string
 
 	// Raw claims returned by the server.
@@ -116,24 +136,32 @@ func (self *Provider) GetResourceRegistrationURL() string {
 }
 
 type providerJSON struct {
-	Issuer string `json:"issuer"`
-	TokenURL string `json:"token_endpoint"`
+	Issuer                  string `json:"issuer"`
+	TokenURL                string `json:"token_endpoint"`
 	ResourceRegistrationURL string `json:"resource_registration_endpoint"`
 }
 
 func unmashalJSONResponse(resp *http.Response, v interface{}, b *[]byte) error {
 	// read response body
 	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil { return fmt.Errorf("unable to read response body: %v", err) }
+	if err != nil {
+		return fmt.Errorf("unable to read response body: %v", err)
+	}
 
-	if b != nil { *b = body }
+	if b != nil {
+		*b = body
+	}
 
 	// check http status ok
-	if resp.StatusCode != http.StatusOK { return fmt.Errorf("%s: %s", resp.Status, body) }
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%s: %s", resp.Status, body)
+	}
 
 	// decode as json and return if ok
 	err = json.Unmarshal(body, v)
-	if err == nil { return nil }
+	if err == nil {
+		return nil
+	}
 
 	// check json response content type
 	ct := resp.Header.Get("Content-Type")

--- a/pkg/config/metadata/user_info.go
+++ b/pkg/config/metadata/user_info.go
@@ -1,26 +1,26 @@
 package metadata
 
 import (
-	"net/url"
-	"net/http"
 	"encoding/json"
+	"net/http"
+	"net/url"
 
-	"github.com/3scale/authorino/pkg/config/internal"
+	"github.com/3scale/authorino/pkg/common"
 	"github.com/3scale/authorino/pkg/config/identity"
 )
 
 type UserInfo struct {
-	OIDC string `yaml:"oidc,omitempty"`
-	ClientID string `yaml:"client_id"`
+	OIDC         string `yaml:"oidc,omitempty"`
+	ClientID     string `yaml:"client_id"`
 	ClientSecret string `yaml:"client_secret"`
 }
 
-func (self *UserInfo) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *UserInfo) Call(ctx common.AuthContext) (interface{}, error) {
 	// find oidc config and the userinfo endpoint
 	idConfig, _ := ctx.FindIdentityByName(self.OIDC)
 	idConfigStruct := idConfig.(identity.OIDC)
 	provider, _ := idConfigStruct.NewProvider(ctx)
-	var providerClaims map[string] interface{}
+	var providerClaims map[string]interface{}
 	_ = provider.Claims(&providerClaims)
 	userInfoURL, _ := url.Parse(providerClaims["introspection_endpoint"].(string))
 	userInfoURL.User = url.UserPassword(self.ClientID, self.ClientSecret)
@@ -30,17 +30,21 @@ func (self *UserInfo) Call(ctx internal.AuthContext) (interface{}, error) {
 
 	// fetch user info
 	formData := url.Values{
-		"token": {accessToken},
+		"token":           {accessToken},
 		"token_type_hint": {"requesting_party_token"},
 	}
 	resp, err := http.PostForm(userInfoURL.String(), formData)
-  if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 	defer resp.Body.Close()
 
 	// parse the response
 	var claims map[string]interface{}
 	err = json.NewDecoder(resp.Body).Decode(&claims)
-	if err != nil { return nil, err }
+	if err != nil {
+		return nil, err
+	}
 
 	return claims, nil
 }


### PR DESCRIPTION
Proposal to avoid DRY for concurrent authcontext calls. Working out further your data structures and working with interfaces may improve further this implementation. But with the current data structures, this is the best I could come up with.

IMO, right now, the additional structure copies and the deteriorated code legibility does not pay off. But up to you. With better data structures, it can be interesting. 

PS: Sorry about all the formatting "noise". That is the output of `go fmt`, which is the standard one. My IDE executes `go fmt` every now and then. Focus on the refactor of `GetIDObject`, `GetMDObject` and `GetAuthObject`.