### PR TITLE
Renaming `config/internal` package to `config/common`

### DIFF
--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	"github.com/3scale-labs/authorino/pkg/config/authorization"
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
 type AuthorizationConfig struct {
@@ -12,7 +12,7 @@ type AuthorizationConfig struct {
 	JWT *authorization.JWTClaims `yaml:"jwt"`
 }
 
-func (self *AuthorizationConfig) Call(ctx internal.AuthContext) (bool, error) {
+func (self *AuthorizationConfig) Call(ctx common.AuthContext) (bool, error) {
 	switch {
 	case self.OPA != nil:
 		return self.OPA.Call(ctx)

--- a/pkg/config/authorization/jwt.go
+++ b/pkg/config/authorization/jwt.go
@@ -1,7 +1,7 @@
 package authorization
 
 import (
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
 type JWTClaims struct {
@@ -21,7 +21,7 @@ func (self *JWTClaims) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return nil
 }
 
-func (self *JWTClaims) Call(ctx internal.AuthContext) (bool, error) {
+func (self *JWTClaims) Call(ctx common.AuthContext) (bool, error) {
 	if !self.Enabled {
 		return true, nil
 	}

--- a/pkg/config/authorization/opa.go
+++ b/pkg/config/authorization/opa.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"log"
 
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
 	"github.com/open-policy-agent/opa/rego"
@@ -81,7 +81,7 @@ func (self *OPAInput) ToJSON() ([]byte, error) {
 	return res, nil
 }
 
-func (self *OPA) Call(ctx internal.AuthContext) (bool, error) {
+func (self *OPA) Call(ctx common.AuthContext) (bool, error) {
 	if !self.Enabled {
 		return true, nil
 	}

--- a/pkg/config/common/auth_context.go
+++ b/pkg/config/common/auth_context.go
@@ -1,4 +1,4 @@
-package internal
+package common
 
 import (
 	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -3,8 +3,8 @@ package config
 import (
 	"fmt"
 
+	"github.com/3scale-labs/authorino/pkg/config/common"
 	"github.com/3scale-labs/authorino/pkg/config/identity"
-	"github.com/3scale-labs/authorino/pkg/config/internal"
 )
 
 type IdentityConfig struct {
@@ -14,7 +14,7 @@ type IdentityConfig struct {
 	APIKey *identity.APIKey `yaml:"api_key,omitempty"`
 }
 
-func (self *IdentityConfig) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *IdentityConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	switch {
 	case self.OIDC != nil:
 		return self.OIDC.Call(ctx)

--- a/pkg/config/identity/api_key.go
+++ b/pkg/config/identity/api_key.go
@@ -1,13 +1,13 @@
 package identity
 
 import (
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
 type APIKey struct {
 	SecretKey string `yaml:"secret_key"`
 }
 
-func (self *APIKey) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *APIKey) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with API key", nil // TODO: implement
 }

--- a/pkg/config/identity/hmac.go
+++ b/pkg/config/identity/hmac.go
@@ -1,13 +1,11 @@
 package identity
 
-import (
-	"github.com/3scale-labs/authorino/pkg/config/internal"
-)
+import "github.com/3scale-labs/authorino/pkg/config/common"
 
 type HMAC struct {
 	Secret string `yaml:"secret"`
 }
 
-func (self *HMAC) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *HMAC) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with HMAC", nil // TODO: implement
 }

--- a/pkg/config/identity/mtls.go
+++ b/pkg/config/identity/mtls.go
@@ -1,13 +1,13 @@
 package identity
 
 import (
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
 type MTLS struct {
 	PEM string `yaml:"pem"`
 }
 
-func (self *MTLS) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *MTLS) Call(ctx common.AuthContext) (interface{}, error) {
 	return "Authenticated with mTLS", nil // TODO: implement
 }

--- a/pkg/config/identity/oidc.go
+++ b/pkg/config/identity/oidc.go
@@ -3,7 +3,7 @@ package identity
 import (
 	"context"
 
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 
 	oidc "github.com/coreos/go-oidc"
 )
@@ -13,7 +13,7 @@ type OIDC struct {
 	Endpoint string `yaml:"endpoint"`
 }
 
-func (self *OIDC) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *OIDC) Call(ctx common.AuthContext) (interface{}, error) {
 	// extract access token
 	accessToken, err := ctx.AuthorizationToken()
 	if err != nil {
@@ -41,7 +41,7 @@ func (self *OIDC) Call(ctx internal.AuthContext) (interface{}, error) {
 	return claims, nil
 }
 
-func (self *OIDC) NewProvider(ctx internal.AuthContext) (*oidc.Provider, error) {
+func (self *OIDC) NewProvider(ctx common.AuthContext) (*oidc.Provider, error) {
 	provider, err := oidc.NewProvider(context.TODO(), self.Endpoint)
 	if err != nil {
 		return nil, err

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -3,7 +3,7 @@ package config
 import (
 	"fmt"
 
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 	"github.com/3scale-labs/authorino/pkg/config/metadata"
 )
 
@@ -12,7 +12,7 @@ type MetadataConfig struct {
 	UMA      *metadata.UMA      `yaml:"uma,omitempty"`
 }
 
-func (self *MetadataConfig) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *MetadataConfig) Call(ctx common.AuthContext) (interface{}, error) {
 	t, _ := self.GetType()
 	switch t {
 	case "userinfo":

--- a/pkg/config/metadata/uma.go
+++ b/pkg/config/metadata/uma.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"strings"
 
-	"github.com/3scale-labs/authorino/pkg/config/internal"
+	"github.com/3scale-labs/authorino/pkg/config/common"
 )
 
 type UMA struct {
@@ -18,7 +18,7 @@ type UMA struct {
 	ClientSecret string `yaml:"client_secret"`
 }
 
-func (self *UMA) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *UMA) Call(ctx common.AuthContext) (interface{}, error) {
 	// discover uma config
 	provider, err := self.NewProvider(ctx)
 	if err != nil {
@@ -61,7 +61,7 @@ func (self *UMA) Call(ctx internal.AuthContext) (interface{}, error) {
 	return resourceData, nil
 }
 
-func (self *UMA) NewProvider(ctx internal.AuthContext) (*Provider, error) {
+func (self *UMA) NewProvider(ctx common.AuthContext) (*Provider, error) {
 	// discover uma config
 	wellKnown := strings.TrimSuffix(self.Endpoint, "/") + "/.well-known/uma2-configuration"
 	resp, err := http.Get(wellKnown)

--- a/pkg/config/metadata/user_info.go
+++ b/pkg/config/metadata/user_info.go
@@ -5,8 +5,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/3scale-labs/authorino/pkg/config/common"
 	"github.com/3scale-labs/authorino/pkg/config/identity"
-	"github.com/3scale-labs/authorino/pkg/config/internal"
 )
 
 type UserInfo struct {
@@ -15,7 +15,7 @@ type UserInfo struct {
 	ClientSecret string `yaml:"client_secret"`
 }
 
-func (self *UserInfo) Call(ctx internal.AuthContext) (interface{}, error) {
+func (self *UserInfo) Call(ctx common.AuthContext) (interface{}, error) {
 	// find oidc config and the userinfo endpoint
 	idConfig, _ := ctx.FindIdentityByName(self.OIDC)
 	idConfigStruct := idConfig.(*identity.OIDC)


### PR DESCRIPTION
As a rule proposed in Go 1.4 and applied when vendoring was added in Go 1.5:

> An import of a path containing the element “internal” is disallowed if the importing code is outside the tree rooted at the parent of the “internal” directory.

Also, to avoid build failures such as:
<img width="1535" alt="Screenshot 2021-01-25 at 15 00 00" src="https://user-images.githubusercontent.com/4183971/105678232-79fa3e00-5f1f-11eb-8726-0d2f1a03a73a.png">
