### PR TITLE
Fix AuthService RPC x HTTP status code mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Authorino complies with the [3scale Ostia architecture](https://github.com/3scal
 3. **Identity verification step** - Authorino verifies the identity of the the original requestor, where at least one authentication method/identity provider should answer
 4. **Ad-hoc authorization metadata step** - Authorino integrates external sources to add metadata to the authorization payload, such as user info, attributes of the requested resource and payload-mutating web hooks
 5. **Policy enforcement step** - Authorino dispatches authorization policy evaluation to one or more configured Policy Decision Points (PDP)
-6. Authorino and Envoy settle the authorization protocol with either a `200 OK`, `403 Forbidden` or `404 Not found` response
+6. Authorino and Envoy settle the authorization protocol with either a `200 OK`, `403 Forbidden` or `404 Not found` response (_Tip:_ with extra details available in the `x-ext-auth-reason` header if NOK)
 7. If authorized, Envoy redirects to the requested _Upstream_
 8. The Upstream serves the requested resource
 
@@ -435,7 +435,7 @@ export ACCESS_TOKEN_JOHN=$(curl -k -d 'grant_type=password' -d 'client_id=demo' 
 
 curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JOHN" http://localhost:8000/hello -v        # 200 OK
 curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JOHN" http://localhost:8000/greetings/1 -v  # 200 OK
-curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JOHN" http://localhost:8000/bye -v          # 401 Unauthorized
+curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JOHN" http://localhost:8000/bye -v          # 403 Forbidden
 ```
 
 #### 4. Try out with Jane (admin)
@@ -446,7 +446,7 @@ Jane is an admin user of the `ostia` realm in Keycloak. She does not own any res
 export ACCESS_TOKEN_JANE=$(curl -k -d 'grant_type=password' -d 'client_id=demo' -d 'username=jane' -d 'password=p' "http://localhost:8080/auth/realms/ostia/protocol/openid-connect/token" | jq -r '.access_token')
 
 curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JANE" http://localhost:8000/hello -v        # 200 OK
-curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JANE" http://localhost:8000/greetings/1 -v  # 401 Unauthorized
+curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JANE" http://localhost:8000/greetings/1 -v  # 403 Forbidden
 curl -H 'Host: echo-api' -H "Authorization: Bearer $ACCESS_TOKEN_JANE" http://localhost:8000/bye -v          # 200 OK
 ```
 

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -16,6 +16,12 @@ import (
 
 var (
 	authServiceLog = ctrl.Log.WithName("Authorino").WithName("AuthService")
+
+	statusCodeMapping = map[rpc.Code]envoy_type.StatusCode{
+		rpc.FAILED_PRECONDITION: envoy_type.StatusCode_BadRequest,
+		rpc.NOT_FOUND:           envoy_type.StatusCode_NotFound,
+		rpc.PERMISSION_DENIED:   envoy_type.StatusCode_Forbidden,
+	}
 )
 
 // AuthService is the server API for the authorization service.
@@ -71,17 +77,16 @@ func (self *AuthService) deniedResponse(code rpc.Code, message string) *auth.Che
 		HttpResponse: &auth.CheckResponse_DeniedResponse{
 			DeniedResponse: &auth.DeniedHttpResponse{
 				Status: &envoy_type.HttpStatus{
-					Code: envoy_type.StatusCode_Unauthorized,
+					Code: statusCodeMapping[code],
 				},
 				Headers: []*core.HeaderValueOption{
 					{
 						Header: &core.HeaderValue{
 							Key:   "x-ext-auth-reason",
-							Value: "forbidden",
+							Value: message,
 						},
 					},
 				},
-				Body: message,
 			},
 		},
 	}

--- a/pkg/service/auth_test.go
+++ b/pkg/service/auth_test.go
@@ -1,0 +1,45 @@
+package service
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+
+	"github.com/3scale-labs/authorino/pkg/cache"
+
+	envoy_core "github.com/envoyproxy/go-control-plane/envoy/api/v2/core"
+	auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v2"
+	envoy_type "github.com/envoyproxy/go-control-plane/envoy/type"
+	"github.com/gogo/googleapis/google/rpc"
+)
+
+func TestDeniedResponse(t *testing.T) {
+	c := cache.NewCache()
+	service := AuthService{
+		Cache: &c,
+	}
+
+	var resp *auth.DeniedHttpResponse
+
+	findAuthReason := func(headers []*envoy_core.HeaderValueOption) string {
+		for i := range headers {
+			header := headers[i].Header
+			if header.GetKey() == "x-ext-auth-reason" {
+				return header.GetValue()
+			}
+		}
+		return ""
+	}
+
+	resp = service.deniedResponse(rpc.FAILED_PRECONDITION, "Invalid request").GetDeniedResponse()
+	assert.Equal(t, envoy_type.StatusCode_BadRequest, resp.Status.Code)
+	assert.Equal(t, "Invalid request", findAuthReason(resp.GetHeaders()))
+
+	resp = service.deniedResponse(rpc.NOT_FOUND, "Service not found").GetDeniedResponse()
+	assert.Equal(t, envoy_type.StatusCode_NotFound, resp.Status.Code)
+	assert.Equal(t, "Service not found", findAuthReason(resp.GetHeaders()))
+
+	resp = service.deniedResponse(rpc.PERMISSION_DENIED, "Unauthorized").GetDeniedResponse()
+	assert.Equal(t, envoy_type.StatusCode_Forbidden, resp.Status.Code)
+	assert.Equal(t, "Unauthorized", findAuthReason(resp.GetHeaders()))
+}


### PR DESCRIPTION
Fixes the RPC to HTTP status code mapping so, instead of HTTP `401 Unauthorized`, it will now do proper mapping:

| GRPC | HTTP |
|-------|-------|
| FAILED_PRECONDITION | 400 Bad request |
| NOT_FOUND | 404 Not found |
| PERMISSION_DENIED | 403 Forbidden |

It also modifies so Authorino no longer returns the reason for the auth failure when NOK in the response body as before. Instead, it will now pass the reason in the HTTP response header `x-ext-auth-reason`. This header was previously always filled with the fixed value "forbidden" in such cases.