### PR TITLE
make local-deploy

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -145,3 +145,8 @@ endif
 .PHONY: local-setup
 local-setup: kustomize kind
 	utils/local-setup.sh
+
+# Rebuild and push the docker image and redeploy authorino to the local k8s cluster
+.PHONY: local-deploy
+local-deploy: kind
+	utils/local-deploy.sh

--- a/utils/local-deploy.sh
+++ b/utils/local-deploy.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+set -euo pipefail
+
+export AUTHORINO_NAMESPACE="authorino"
+export KIND_CLUSTER_NAME="authorino-integration"
+
+echo "Building Authorino"
+docker build -t authorino:devel ./
+kind load docker-image authorino:devel --name ${KIND_CLUSTER_NAME}
+
+echo "Deploying Authorino"
+kubectl -n ${AUTHORINO_NAMESPACE} rollout restart $(kubectl -n ${AUTHORINO_NAMESPACE} get deployments -l app=authorino -l control-plane=controller-manager -o name)


### PR DESCRIPTION
Make target to ease rebuilding and redeploying Authorino to the local Kubernetes cluster