### PR TITLE
[Fix] Removes `Location` and `KeySelector` from APIKey Identity

### DIFF
--- a/api/v1beta1/service_types.go
+++ b/api/v1beta1/service_types.go
@@ -62,8 +62,6 @@ type Identity_OidcConfig struct {
 }
 
 type Identity_APIKey struct {
-	Location       string            `json:"location"`
-	KeySelector    string            `json:"key_selector"`
 	LabelSelectors map[string]string `json:"label_selectors"`
 }
 

--- a/config/crd/bases/config.authorino.3scale.net_services.yaml
+++ b/config/crd/bases/config.authorino.3scale.net_services.yaml
@@ -73,6 +73,15 @@ spec:
             identity:
               items:
                 properties:
+                  api_key:
+                    properties:
+                      label_selectors:
+                        additionalProperties:
+                          type: string
+                        type: object
+                    required:
+                    - label_selectors
+                    type: object
                   credentials:
                     properties:
                       in:


### PR DESCRIPTION
Both are part of `Credentials` type.