### PR TITLE
K8s secret reconciler

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -1,0 +1,71 @@
+package controllers
+
+import (
+	"context"
+	"reflect"
+
+	"github.com/3scale-labs/authorino/api/v1beta1"
+	configv1beta1 "github.com/3scale-labs/authorino/api/v1beta1"
+
+	"github.com/go-logr/logr"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+const authorinoWatchedSecretLabel = "authorino.3scale.net/managed-by"
+
+// SecretReconciler reconciles k8s Secret objects
+type SecretReconciler struct {
+	client.Client
+	Log               logr.Logger
+	Scheme            *runtime.Scheme
+	ServiceReconciler reconcile.Reconciler
+}
+
+func (r *SecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	ctx := context.Background()
+	log := r.Log.WithValues("secret", req.NamespacedName)
+
+	secret := v1.Secret{}
+	if err := r.Client.Get(ctx, req.NamespacedName, &secret); err != nil && !errors.IsNotFound(err) {
+		return ctrl.Result{}, err
+	}
+
+	// return if not an Authorino-watched secret
+	if _, watched := secret.Labels[authorinoWatchedSecretLabel]; !watched {
+		// FIXME: Authorino won't be able to fetch the secret's labels if the secret was deleted, so it will end up not reconciling the services anyway
+		return ctrl.Result{}, nil
+	}
+
+	var serviceList = &configv1beta1.ServiceList{}
+	if err := r.List(ctx, serviceList); err != nil {
+		log.Info("could not fetch list of services", "object", req)
+		return ctrl.Result{}, nil
+	} else {
+		for _, service := range serviceList.Items {
+			for _, id := range service.Spec.Identity {
+				if id.GetType() == v1beta1.IdentityApiKey && reflect.DeepEqual(id.APIKey.LabelSelectors, secret.Labels) {
+					_, _ = r.ServiceReconciler.Reconcile(ctrl.Request{
+						NamespacedName: types.NamespacedName{
+							Namespace: service.Namespace,
+							Name:      service.Name,
+						},
+					})
+				}
+			}
+		}
+	}
+
+	return ctrl.Result{}, nil
+}
+
+func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&v1.Secret{}).
+		Complete(r)
+}

--- a/controllers/secret_controller_test.go
+++ b/controllers/secret_controller_test.go
@@ -1,0 +1,150 @@
+package controllers
+
+import (
+	"testing"
+
+	"github.com/3scale-labs/authorino/api/v1beta1"
+	"gotest.tools/assert"
+
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	controllerruntime "sigs.k8s.io/controller-runtime"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type fakeReconciler struct {
+	Reconciled bool
+}
+
+func (r *fakeReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
+	r.Reconciled = true
+	return ctrl.Result{}, nil
+}
+
+type secretReconcilerTest struct {
+	secret            v1.Secret
+	service           v1beta1.Service
+	serviceReconciler *fakeReconciler
+	secretReconciler  *SecretReconciler
+}
+
+func newSecretReconcilerTest(secretLabels map[string]string) secretReconcilerTest {
+	secret := v1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Secret",
+			APIVersion: "v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bill",
+			Namespace: "authorino",
+			Labels:    secretLabels,
+		},
+		Data: map[string][]byte{
+			"api_key": []byte("123456"),
+		},
+	}
+
+	service := v1beta1.Service{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Service",
+			APIVersion: "config.authorino.3scale.net/v1beta1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service1",
+			Namespace: "authorino",
+		},
+		Spec: v1beta1.ServiceSpec{
+			Hosts: []string{"echo-api"},
+			Identity: []*v1beta1.Identity{
+				{
+					Name: "friends",
+					APIKey: &v1beta1.Identity_APIKey{
+						LabelSelectors: map[string]string{
+							"authorino.3scale.net/managed-by": "authorino",
+							"target":                          "echo-api",
+						},
+					},
+				},
+			},
+			Metadata:      []*v1beta1.Metadata{},
+			Authorization: []*v1beta1.Authorization{},
+		},
+		Status: v1beta1.ServiceStatus{
+			Ready: false,
+		},
+	}
+
+	scheme := runtime.NewScheme()
+	_ = v1beta1.AddToScheme(scheme)
+	_ = v1.AddToScheme(scheme)
+	// Create a fake client with a service and a secret.
+	client := fake.NewFakeClientWithScheme(scheme, &service, &secret)
+
+	serviceReconciler := &fakeReconciler{}
+
+	secretReconciler := &SecretReconciler{
+		Client:            client,
+		Log:               ctrl.Log.WithName("reconcilerTest"),
+		Scheme:            nil,
+		ServiceReconciler: serviceReconciler,
+	}
+
+	t := secretReconcilerTest{
+		secret,
+		service,
+		serviceReconciler,
+		secretReconciler,
+	}
+
+	return t
+}
+
+func (t *secretReconcilerTest) reconcile() (reconcile.Result, error) {
+	return t.secretReconciler.Reconcile(controllerruntime.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: t.secret.Namespace,
+			Name:      t.secret.Name,
+		},
+	})
+}
+
+func TestMissingAuthorinoLabel(t *testing.T) {
+	// secret missing the authorino "managed-by" label
+	reconcilerTest := newSecretReconcilerTest(map[string]string{
+		"authorino.3scale.net/managed-by": "authorino",
+	})
+
+	_, err := reconcilerTest.reconcile()
+
+	assert.Check(t, !reconcilerTest.serviceReconciler.Reconciled)
+	assert.NilError(t, err)
+}
+
+func TestSameLabelsAsService(t *testing.T) {
+	// secret with the authorino "managed-by" label and the same labels as the service
+	reconcilerTest := newSecretReconcilerTest(map[string]string{
+		"authorino.3scale.net/managed-by": "authorino",
+		"target":                          "echo-api",
+	})
+
+	_, err := reconcilerTest.reconcile()
+
+	assert.Check(t, reconcilerTest.serviceReconciler.Reconciled)
+	assert.NilError(t, err)
+}
+
+func TestUnmatchingLabels(t *testing.T) {
+	// secret with the authorino "managed-by" label but not the same labels as the service
+	reconcilerTest := newSecretReconcilerTest(map[string]string{
+		"authorino.3scale.net/managed-by": "authorino",
+	})
+
+	_, err := reconcilerTest.reconcile()
+
+	assert.Check(t, !reconcilerTest.serviceReconciler.Reconciled)
+	assert.NilError(t, err)
+}

--- a/examples/echo-api-key-simple.yaml
+++ b/examples/echo-api-key-simple.yaml
@@ -12,12 +12,7 @@ spec:
         key_selector: X-API-KEY # user defined
       api_key:
         label_selectors:
+          authorino.3scale.net/managed-by: authorino
           target: echo-api # user defined
   metadata: []
-  authorization:
-    - JWTClaimSet:
-        match:
-          http:
-            path: "/api/*"
-        claim:
-          aud: "api"
+  authorization: []


### PR DESCRIPTION
Closes #65

----

Introduces the requirement for k8s secrets meant for being used as API keys to always include a label `authorino.3scale.net/managed-by` (with whatever non-null value). Consequently, all services configured for API key authentication must as well include in its `label_selectors` of the `api_key` identity config this new label `authorino.3scale.net/managed-by` (with value matching the one used in the secrets).

A limitation of the implementation here presented is that deleted secrets trigger the reconciler but cannot be checked for matching labels and corresponding affected services. This makes a bit harder for the revoking of access to services by deleting the secrets. Two possible workarounds to this limitation are:
- i) first update the secret before deleting it (i.e. remove the `api_key` entry or change its value)
- ii) enhance with authorization policies that check attributes of the resolved secret (e.g. use the secret's `creationTimestamp` for short-lived API keys working as access tokens)