### PR TITLE
Auth Credentials: Default values

### DIFF
--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -106,10 +106,7 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 			Name: identity.Name,
 		}
 
-		authCred := &auth_credentials.AuthCredential{
-			KeySelector: identity.Credentials.KeySelector,
-			In:          identity.Credentials.In,
-		} // TODO: prepare for when missing credentials field
+		authCred := auth_credentials.NewAuthCredential(identity.Credentials.KeySelector, identity.Credentials.In)
 
 		switch identity.GetType() {
 		// oidc

--- a/pkg/common/auth_credentials/auth_credentials.go
+++ b/pkg/common/auth_credentials/auth_credentials.go
@@ -26,6 +26,8 @@ const (
 	inCookieHeader = "cookie"
 	inQuery        = "query"
 
+	defaultKeySelector = "Bearer"
+
 	credentialNotFoundMsg             = "credential not found"
 	credentialNotFoundInHeaderMsg     = "the credential was not found in the request header"
 	credentialLocationNotSupportedMsg = "the credential location is not supported"
@@ -40,9 +42,17 @@ var (
 
 // NewAuthCredential creates a new instance of AuthCredential
 func NewAuthCredential(selector string, location string) *AuthCredential {
+	var keySelector, in string
+	if keySelector = selector; keySelector == "" {
+		keySelector = defaultKeySelector
+	}
+	if in = location; in == "" {
+		in = inAuthHeader
+	}
+
 	return &AuthCredential{
-		selector,
-		location,
+		keySelector,
+		in,
 	}
 }
 

--- a/pkg/common/auth_credentials/auth_credentials_test.go
+++ b/pkg/common/auth_credentials/auth_credentials_test.go
@@ -16,12 +16,19 @@ func TestConstants(t *testing.T) {
 	assert.Check(t, "the credential location is not supported" == credentialLocationNotSupportedMsg)
 	assert.Check(t, "the Authorization header is not set" == authHeaderNotSetMsg)
 	assert.Check(t, "the Cookie header is not set" == cookieHeaderNotSetMsg)
+	assert.Check(t, "Bearer" == defaultKeySelector)
 }
 
 func TestNewAuthCredential(t *testing.T) {
 	creds := NewAuthCredential("api_key", "query")
 	assert.Check(t, creds.KeySelector == "api_key")
 	assert.Check(t, creds.In == "query")
+}
+
+func TestNewAuthCredentialDefaultValues(t *testing.T) {
+	creds := NewAuthCredential("", "")
+	assert.Check(t, creds.KeySelector == "Bearer")
+	assert.Check(t, creds.In == "authorization_header")
 }
 
 func TestGetCredentialsLocationNotSupported(t *testing.T) {


### PR DESCRIPTION
Closes https://github.com/3scale-labs/authorino/issues/71

* default KeySelector is `Bearer`
* default In (location) is `authorization_header`