### PR TITLE
UMA metadata independent from OIDC identity config

### DIFF
--- a/api/v1beta1/service_types.go
+++ b/api/v1beta1/service_types.go
@@ -87,8 +87,8 @@ type Metadata_UserInfo struct {
 	IdentitySource string `json:"identitySource"`
 }
 type Metadata_UMA struct {
-	IdentitySource string                   `json:"identitySource"`
-	Credentials    *v1.LocalObjectReference `json:"credentialsRef,omitempty"`
+	Endpoint    string                   `json:"endpoint"`
+	Credentials *v1.LocalObjectReference `json:"credentialsRef"`
 }
 
 type Authorization struct {

--- a/config/crd/bases/config.authorino.3scale.net_services.yaml
+++ b/config/crd/bases/config.authorino.3scale.net_services.yaml
@@ -141,10 +141,11 @@ spec:
                               TODO: Add other useful fields. apiVersion, kind, uid?'
                             type: string
                         type: object
-                      identitySource:
+                      endpoint:
                         type: string
                     required:
-                    - identitySource
+                    - credentialsRef
+                    - endpoint
                     type: object
                   userInfo:
                     description: Metadata_UserInfo & Metadata_UMA are the same right

--- a/controllers/service_controller.go
+++ b/controllers/service_controller.go
@@ -142,26 +142,22 @@ func (r *ServiceReconciler) translateService(ctx context.Context,
 		switch metadata.GetType() {
 		// uma
 		case configv1beta1.MetadataUma:
-			translatedMetadata.UMA = &authorinoMetadata.UMA{}
-
-			// TODO: validate the object on creating to make sure the secret exist? or just retry?
-			if metadata.UMA.Credentials != nil {
-				secret := &v1.Secret{}
-				if err := r.Client.Get(ctx, types.NamespacedName{
-					Namespace: service.Namespace,
-					Name:      metadata.UMA.Credentials.Name},
-					secret); err != nil {
-					return nil, err // TODO: Review this error, perhaps we don't need to return an error, just reenqueue.
-				}
-
-				translatedMetadata.UMA.ClientID = string(secret.Data["clientID"])
-				translatedMetadata.UMA.ClientSecret = string(secret.Data["clientSecret"])
+			secret := &v1.Secret{}
+			if err := r.Client.Get(ctx, types.NamespacedName{
+				Namespace: service.Namespace,
+				Name:      metadata.UMA.Credentials.Name},
+				secret); err != nil {
+				return nil, err // TODO: Review this error, perhaps we don't need to return an error, just reenqueue.
 			}
-			// Find the actual name for the Identity Source and use that information for the translated object.
-			if idConfig, err := findIdentityConfigByName(identityConfigs, metadata.UMA.IdentitySource); err != nil {
+
+			if uma, err := authorinoMetadata.NewUMAMetadata(
+				metadata.UMA.Endpoint,
+				string(secret.Data["clientID"]),
+				string(secret.Data["clientSecret"]),
+			); err != nil {
 				return nil, err
 			} else {
-				translatedMetadata.UMA.Endpoint = idConfig.OIDC.Endpoint
+				translatedMetadata.UMA = uma
 			}
 
 		// user_info

--- a/examples/echo-api-protection.yaml
+++ b/examples/echo-api-protection.yaml
@@ -18,7 +18,7 @@ spec:
         identitySource: keycloak
     - name: resource-data
       uma:
-        identitySource: keycloak
+        endpoint: http://keycloak:8080/auth/realms/ostia
         credentialsRef:
           name: umacredentialssecret
   authorization:

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	google.golang.org/genproto v0.0.0-20191108220845-16a3f7862a1a
 	google.golang.org/grpc v1.27.0
 	gopkg.in/square/go-jose.v2 v2.5.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gotest.tools v2.2.0+incompatible
 	k8s.io/api v0.18.6
 	k8s.io/apimachinery v0.18.6

--- a/go.sum
+++ b/go.sum
@@ -95,7 +95,6 @@ github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb
 github.com/emicklei/go-restful v2.9.5+incompatible/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=
 github.com/envoyproxy/go-control-plane v0.6.9/go.mod h1:SBwIajubJHhxtWwsL9s8ss4safvEdbitLhGGK48rN6g=
 github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
-github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473 h1:4cmBvAEBNJaGARUEs3/suWRyfyBfhf7I60WBZq+bv2w=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.8 h1:bbmjRkjmP0ZggMoahdNMmJFFnK7v5H+/j5niP5QH6bg=
 github.com/envoyproxy/go-control-plane v0.9.8/go.mod h1:cXg6YxExXjJnVBQHBLXeUAgxn2UodCpnH306RInaBQk=
@@ -179,7 +178,6 @@ github.com/gogo/googleapis v1.3.0/go.mod h1:d+q1s/xVJxZGKWwC/6UfPIF33J+G1Tq4GYv9
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.1/go.mod h1:hp+jE20tsWTFYpLwKvXlhS1hjn+gTNwPg2I6zVXpSg4=
-github.com/gogo/protobuf v1.3.0 h1:G8O7TerXerS4F6sx9OV7/nRfJdnXgHZu/S/7F2SN+UE=
 github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.1 h1:DqDEcV5aeaTmdFBePNpYsp3FlcVH/2ISVVM9Qf8PSls=
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
@@ -190,14 +188,12 @@ github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6 h1:ZgQEtGgCBiWRM39fZuwSd1LwSqqSW0hOdXCYYDX0R3I=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/mock v1.1.1/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
-github.com/golang/mock v1.2.0 h1:28o5sBqPkBsMGnC6b4MvE2TzSr5/AT4c/1fLqVGIwlk=
 github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfbm0A=
 github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
 github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8=
 github.com/golang/protobuf v0.0.0-20161109072736-4bd1920723d7/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
-github.com/golang/protobuf v1.3.2 h1:6nsPYzhq5kReh6QImI3k5qWzO4PEbvbIW2cwSfR/6xs=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
@@ -233,7 +229,6 @@ github.com/gophercloud/gophercloud v0.1.0/go.mod h1:vxM41WHh5uqHVBMZHzuwNOHh8XEo
 github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
 github.com/gorilla/mux v1.6.2/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
-github.com/gorilla/mux v1.7.3 h1:gnP5JzjVOuiZD07fKKToCAOjS0yOpj/qPETTXCCS6hw=
 github.com/gorilla/mux v1.7.3/go.mod h1:1lud6UwP+6orDFRuTfBEV8e9/aOM/c4fVVCaMa2zaAs=
 github.com/gorilla/websocket v0.0.0-20170926233335-4201258b820c/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
@@ -309,7 +304,6 @@ github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaO
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-isatty v0.0.4/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/matttproud/golang_protobuf_extensions v1.0.1 h1:4hp9jkHxhMHkqkrB3Ix0jegS5sx/RkqARlsWZ6pIwiU=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
@@ -345,7 +339,6 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/olekukonko/tablewriter v0.0.0-20170122224234-a0225b3f23b5/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
-github.com/olekukonko/tablewriter v0.0.1 h1:b3iUnf1v+ppJiOfNX4yxxqfWKMQPZR5yoh8urCTFX88=
 github.com/olekukonko/tablewriter v0.0.1/go.mod h1:vsDQFd/mU46D+Z4whnwzcISnGGzXWMclvtLoiIKAKIo=
 github.com/onsi/ginkgo v0.0.0-20170829012221-11459a886d9c/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
 github.com/onsi/ginkgo v1.6.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+WWjE=
@@ -376,7 +369,6 @@ github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtP
 github.com/pelletier/go-toml v1.2.0/go.mod h1:5z9KED0ma1S8pY6P1sdut58dfprrGBbd/94hg7ilaic=
 github.com/performancecopilot/speed v3.0.0+incompatible/go.mod h1:/CLtqpZ5gBg1M9iaPbIdPPGyKcA8hKdoy6hAWba7Yac=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
-github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d h1:zapSxdmZYY6vJWXFKLQ+MkI+agc+HQyfrCGowDSHiKs=
 github.com/peterh/liner v0.0.0-20170211195444-bf27d3ba8e1d/go.mod h1:xIteQHvHuaLYG9IFj6mSxM0fCKrs34IrEQUhOYuGPHc=
 github.com/pierrec/lz4 v1.0.2-0.20190131084431-473cd7ce01a1/go.mod h1:3/3N9NVKO0jef7pBehbT1qWhCMrIgbYNnFAZCqQ5LRc=
 github.com/pierrec/lz4 v2.0.5+incompatible/go.mod h1:pdkljMzZIN41W+lC3N2tnIh5sFi+IEE17M5jbnwPHcY=
@@ -432,7 +424,6 @@ github.com/sergi/go-diff v1.0.0/go.mod h1:0CfEIISq7TuYL3j771MWULgwwjU+GofnZX9QAm
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.2.0/go.mod h1:LxeOpSwHxABJmUn/MG1IvRgCAasNZTLOkJPxbbu5VWo=
 github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6MwdIuYE2rE=
-github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v1.6.4/go.mod h1:syvi0/a8iFYH4r/RixwvyeAJjdLS9QV7WQ/tjFTllLA=
@@ -441,12 +432,10 @@ github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJ
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/cast v1.3.0/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
-github.com/spf13/cobra v0.0.3 h1:ZlrZ4XsMRm04Fr5pSFxBgfND2EBVa1nLpiy1stUsX/8=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/jwalterweatherman v1.0.0/go.mod h1:cQK4TGJAtQXfYWX+Ddv3mKDzgVb68N+wFjFa4jdeBTo=
 github.com/spf13/pflag v0.0.0-20170130214245-9ff6c6923cff/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
-github.com/spf13/pflag v1.0.1 h1:aCvUg6QPl3ibpQUxyLkrEkCHtPqYJL4x9AuhqVqFis4=
 github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
@@ -509,7 +498,6 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
-golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2 h1:VklqNMn3ovrHsnt90PveolxSbWFaJdECFbxSq0Mqo2M=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20190510104115-cbcb75029529/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
@@ -558,9 +546,7 @@ golang.org/x/net v0.0.0-20200625001655-4c5254603344/go.mod h1:/O7V0waA8r7cgGh81R
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728 h1:5wtQIAulKU5AbLQOkjxl32UufnIOqgBX72pS0AV14H0=
 golang.org/x/net v0.0.0-20200927032502-5d4f70055728/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
-golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be h1:vEDujvNQGv4jgYKudGeI/+DAX4Jffq6hpD55MmoEvKs=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
-golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421 h1:Wo7BWFiOk0QRFMLYMqJGFMd9CgUAcGx7V+qEg/h5IBI=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45 h1:SVwTIAaPC2U/AvvLNZ2a7OVsmBpC8L5BlwK1whH3hm0=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
@@ -570,7 +556,6 @@ golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20190911185100-cd5d95a43a6e/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20170830134202-bb24a47a89ea/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20180823144017-11551d06cbcc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
@@ -602,7 +587,6 @@ golang.org/x/sys v0.0.0-20200615200032-f1bc736245b1/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20160726164857-2910a502d2bf/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
-golang.org/x/text v0.3.0 h1:g61tztE5qeGQ89tm6NTjjM9VPIm088od1l6aSorWRWg=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
@@ -647,7 +631,6 @@ google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMt
 google.golang.org/api v0.4.0/go.mod h1:8k5glujaEP+g9n7WNsDg8QP6cUVNI86fCNMcbazEtwE=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=
 google.golang.org/appengine v1.2.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
-google.golang.org/appengine v1.4.0 h1:/wp5JvzpHIxhs/dumFmF7BXTf3Z+dd4uXta4kVyO508=
 google.golang.org/appengine v1.4.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
 google.golang.org/appengine v1.5.0 h1:KxkO13IPW4Lslp2bz+KHP2E3gtFlrIGNThxkZQ3g+4c=
 google.golang.org/appengine v1.5.0/go.mod h1:xpcJRLb0r/rnEns0DIKYYv+WjYCduHsrkT7/EB5XEv4=
@@ -668,7 +651,6 @@ google.golang.org/grpc v1.22.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyac
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.23.1/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
 google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
-google.golang.org/grpc v1.26.0 h1:2dTRdpdFEEhJYQD8EMLB61nnrzSCTbG38PhqdhvOltg=
 google.golang.org/grpc v1.26.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=

--- a/pkg/common/mocks/http_mocks.go
+++ b/pkg/common/mocks/http_mocks.go
@@ -1,0 +1,41 @@
+package mock_common
+
+import (
+	"log"
+	"net"
+	"net/http"
+	"net/http/httptest"
+)
+
+type HttpServerMockResponses struct {
+	Status  int
+	Headers map[string]string
+	Body    string
+}
+
+func NewHttpServerMock(serverHost string, httpServerMocks map[string]HttpServerMockResponses) *httptest.Server {
+	log.Printf("starting mock http server at %v", serverHost)
+
+	listener, err := net.Listen("tcp", serverHost)
+	if err != nil {
+		panic(err)
+	}
+
+	handler := func(rw http.ResponseWriter, req *http.Request) {
+		for path, response := range httpServerMocks {
+			if path == req.URL.String() {
+				for k, v := range response.Headers {
+					rw.Header().Add(k, v)
+				}
+				rw.WriteHeader(response.Status)
+				_, _ = rw.Write([]byte(response.Body))
+				break
+			}
+		}
+	}
+
+	server := &httptest.Server{Listener: listener, Config: &http.Server{Handler: http.HandlerFunc(handler)}}
+	server.Start()
+
+	return server
+}

--- a/pkg/config/metadata/uma_test.go
+++ b/pkg/config/metadata/uma_test.go
@@ -1,0 +1,83 @@
+package metadata
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	. "github.com/3scale-labs/authorino/pkg/common/mocks"
+
+	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	. "github.com/golang/mock/gomock"
+	"gotest.tools/assert"
+)
+
+type UMATest struct{}
+
+const (
+	umaServerHost = "127.0.0.1:9003"
+)
+
+var (
+	umaIssuer          = fmt.Sprintf("http://%v/uma", umaServerHost)
+	umaWellKnownConfig = fmt.Sprintf(`{
+		"issuer": "%v",
+		"token_endpoint": "%v/pat",
+		"resource_registration_endpoint": "%v/resource_set"
+	}`, umaIssuer, umaIssuer, umaIssuer)
+)
+
+func TestNewUMAMetadata(t *testing.T) {
+	httpServer := NewHttpServerMock(umaServerHost, map[string]HttpServerMockResponses{
+		"/uma/.well-known/uma2-configuration": {Status: 200, Body: umaWellKnownConfig},
+	})
+	defer httpServer.Close()
+
+	uma, err := NewUMAMetadata(umaIssuer, "client-id", "client-secret")
+
+	assert.NilError(t, err)
+	assert.Equal(t, umaIssuer, uma.provider.issuer)
+}
+
+func TestUMAMetadataFailToDecodeConfig(t *testing.T) {
+	httpServer := NewHttpServerMock(umaServerHost, map[string]HttpServerMockResponses{
+		"/uma/.well-known/uma2-configuration": {Status: 500},
+	})
+	defer httpServer.Close()
+
+	uma, err := NewUMAMetadata(umaIssuer, "client-id", "client-secret")
+
+	assert.ErrorContains(t, err, "failed to decode uma provider discovery object")
+	assert.Check(t, uma == nil)
+}
+
+func TestUMACall(t *testing.T) {
+	jsonResponse := func(body string) HttpServerMockResponses {
+		return HttpServerMockResponses{Status: 200, Headers: map[string]string{"Context-Type": "application/json"}, Body: body}
+	}
+
+	resourceData := `{"_id":"44f93c94-a8d0-4b33-8188-8173e86844d2","name":"some-resource","uris":["/someresource"]}`
+	httpServer := NewHttpServerMock(umaServerHost, map[string]HttpServerMockResponses{
+		"/uma/.well-known/uma2-configuration":                    jsonResponse(umaWellKnownConfig),
+		"/uma/pat":                                               jsonResponse(`{"some-pat-claim": "some-value"}`),
+		"/uma/resource_set?uri=/someresource":                    jsonResponse(`["44f93c94-a8d0-4b33-8188-8173e86844d2"]`),
+		"/uma/resource_set/44f93c94-a8d0-4b33-8188-8173e86844d2": jsonResponse(resourceData),
+	})
+	defer httpServer.Close()
+
+	ctrl := NewController(t)
+	defer ctrl.Finish()
+
+	authContextMock := NewMockAuthContext(ctrl)
+	request := &envoy_auth.AttributeContext_HttpRequest{Path: "/someresource"}
+	authContextMock.EXPECT().GetHttp().Return(request)
+
+	uma, _ := NewUMAMetadata(umaIssuer, "client-id", "client-secret")
+
+	obj, err := uma.Call(authContextMock, context.TODO())
+
+	data, _ := json.Marshal(obj)
+	assert.Equal(t, "["+resourceData+"]", string(data))
+	assert.NilError(t, err)
+}

--- a/pkg/config/metadata/user_info_test.go
+++ b/pkg/config/metadata/user_info_test.go
@@ -3,25 +3,19 @@ package metadata
 import (
 	"context"
 	"fmt"
-	"net"
-	"net/http"
-	"net/http/httptest"
 	"os"
 	"testing"
 
-	mock_common "github.com/3scale-labs/authorino/pkg/common/mocks"
-
-	. "github.com/golang/mock/gomock"
-
-	"gotest.tools/assert"
-
+	. "github.com/3scale-labs/authorino/pkg/common/mocks"
 	"github.com/3scale-labs/authorino/pkg/config/identity"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	. "github.com/golang/mock/gomock"
+	"gotest.tools/assert"
 )
 
 const (
-	authServerHost string = "127.0.0.1:9001"
+	authServerHost string = "127.0.0.1:9002"
 	userInfoClaims string = `{ "sub": "831707be-ef07-4d63-b427-4216309e9897" }`
 )
 
@@ -30,11 +24,6 @@ var (
 		"issuer": "http://%s",
 		"userinfo_endpoint": "http://%s/userinfo"
 	}`, authServerHost, authServerHost)
-
-	userInfo UserInfo
-	newOIDC  *identity.OIDC
-	ctx      context.Context
-	cancel   context.CancelFunc
 )
 
 // TODO: replace with gomock
@@ -45,83 +34,63 @@ func (a *authCredMock) GetCredentialsFromReq(*envoy_auth.AttributeContext_HttpRe
 }
 
 func TestMain(m *testing.M) {
-	authServer := mockHTTPServer()
+	authServer := NewHttpServerMock(authServerHost, map[string]HttpServerMockResponses{
+		"/.well-known/openid-configuration": {Status: 200, Body: wellKnownOIDCConfig},
+		"/userinfo":                         {Status: 200, Body: userInfoClaims},
+	})
 	defer authServer.Close()
-	setup()
 	os.Exit(m.Run())
 }
 
-func setup() {
-	newOIDC, _ = identity.NewOIDC(fmt.Sprintf("http://%s", authServerHost), &authCredMock{})
-	userInfo = UserInfo{newOIDC}
-	ctx, cancel = context.WithCancel(context.TODO())
-}
-
-func mockHTTPServer() *httptest.Server {
-	responses := make(map[string]string)
-	responses["/.well-known/openid-configuration"] = wellKnownOIDCConfig
-	responses["/userinfo"] = userInfoClaims
-
-	listener, err := net.Listen("tcp", authServerHost)
-	if err != nil {
-		panic(err)
-	}
-	handler := func(rw http.ResponseWriter, req *http.Request) {
-		for url, response := range responses {
-			if url == req.URL.String() {
-				_, _ = rw.Write([]byte(response))
-				break
-			}
-		}
-	}
-	authServer := &httptest.Server{Listener: listener, Config: &http.Server{Handler: http.HandlerFunc(handler)}}
-	authServer.Start()
-	return authServer
-}
-
-func TestCall(t *testing.T) {
-
+func TestUserInfoCall(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
-	idConfEval := mock_common.NewMockIdentityConfigEvaluator(ctrl)
-	idConfEval.EXPECT().GetOIDC().Return(newOIDC)
+	authContextMock := NewMockAuthContext(ctrl)
+	idConfEval := NewMockIdentityConfigEvaluator(ctrl)
+	oidcEvaluator, _ := identity.NewOIDC(fmt.Sprintf("http://%s", authServerHost), &authCredMock{})
+	idConfEval.EXPECT().GetOIDC().Return(oidcEvaluator)
 	authContextMock.EXPECT().GetHttp().Return(nil)
 	authContextMock.EXPECT().GetResolvedIdentity().Return(idConfEval, nil)
 
-	obj, err := userInfo.Call(authContextMock, ctx)
+	userInfo := UserInfo{oidcEvaluator}
+	obj, err := userInfo.Call(authContextMock, context.TODO())
 	assert.NilError(t, err)
 
 	claims := obj.(map[string]interface{})
 	assert.Equal(t, "831707be-ef07-4d63-b427-4216309e9897", claims["sub"])
 }
 
-func TestCanceledContext(t *testing.T) {
+func TestUserInfoCanceledContext(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
-	idConfEval := mock_common.NewMockIdentityConfigEvaluator(ctrl)
-	idConfEval.EXPECT().GetOIDC().Return(newOIDC)
+	authContextMock := NewMockAuthContext(ctrl)
+	idConfEval := NewMockIdentityConfigEvaluator(ctrl)
+	oidcEvaluator, _ := identity.NewOIDC(fmt.Sprintf("http://%s", authServerHost), &authCredMock{})
+	idConfEval.EXPECT().GetOIDC().Return(oidcEvaluator)
 	authContextMock.EXPECT().GetHttp().Return(nil)
 	authContextMock.EXPECT().GetResolvedIdentity().Return(idConfEval, nil)
 
+	ctx, cancel := context.WithCancel(context.TODO())
 	cancel()
+	userInfo := UserInfo{oidcEvaluator}
 	_, err := userInfo.Call(authContextMock, ctx)
 	assert.Error(t, err, "context canceled")
 }
 
-func TestMissingOIDCConfig(t *testing.T) {
+func TestUserInfoMissingOIDCConfig(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
-	idConfEval := mock_common.NewMockIdentityConfigEvaluator(ctrl)
-	wrongOidc, _ := identity.NewOIDC(fmt.Sprintf("http://wrongServer"), &authCredMock{})
-	idConfEval.EXPECT().GetOIDC().Return(wrongOidc)
+	authContextMock := NewMockAuthContext(ctrl)
+	idConfEval := NewMockIdentityConfigEvaluator(ctrl)
+	oidcEvaluator, _ := identity.NewOIDC(fmt.Sprintf("http://%s", authServerHost), &authCredMock{})
+	otherOidcEvaluator, _ := identity.NewOIDC("http://wrongServer", &authCredMock{})
+	idConfEval.EXPECT().GetOIDC().Return(otherOidcEvaluator)
 	authContextMock.EXPECT().GetResolvedIdentity().Return(idConfEval, nil)
 
-	_, err := userInfo.Call(authContextMock, ctx)
-	assert.Error(t, err, "Missing identity for OIDC issuer http://127.0.0.1:9001. Skipping related UserInfo metadata.")
+	userInfo := UserInfo{oidcEvaluator}
+	_, err := userInfo.Call(authContextMock, context.TODO())
+	assert.ErrorContains(t, err, "Missing identity for OIDC issuer")
 }


### PR DESCRIPTION
Changes the UMA metadata config from this:

```yaml
identity:
  - name: auth-server
    oidc:
      endpoint: http://auth-server
metadata:
  - uma:
    identitySource: auth-server
    credentialsRef:
      name: umacredentialssecret
```

to this:

```yaml
metadata:
  - uma:
      endpoint: http://auth-server
      credentialsRef:
        name: umacredentialssecret
```

Closes #75

----

We didn't have tests for the UMA metadata module yet, so the PR also introduces some. Together with the new tests, there is also a new HTTP server mock helper that makes it easy to map expected HTTP request paths and correspondig responses.