### PR TITLE
make local-setup speed up

### DIFF
--- a/examples/dex.yaml
+++ b/examples/dex.yaml
@@ -1,3 +1,36 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: dex
+data:
+  config.yaml: |
+    issuer: http://dex:5556
+    storage:
+      type: sqlite3
+      config:
+        file: /etc/dex/db/dex.db
+    web:
+      http: 0.0.0.0:5556
+    oauth2:
+      skipApprovalScreen: false
+    logger:
+      level: "debug"
+
+    staticClients:
+    - id: authorino
+      name: 'Authorino'
+      redirectUris:
+      - http://localhost:3000/callback
+      secret: aaf88e0e-d41d-4325-a068-57c4b0d61d8e
+
+    enablePasswordDB: true
+    staticPasswords:
+    - email: "admin@localhost"
+      # bcrypt hash of the string "password"
+      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
+      username: "admin"
+      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
+---
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -38,39 +71,6 @@ spec:
             path: config.yaml
       - name: db
         emptyDir: {} # obviously not good for production
----
-kind: ConfigMap
-apiVersion: v1
-metadata:
-  name: dex
-data:
-  config.yaml: |
-    issuer: http://dex:5556
-    storage:
-      type: sqlite3
-      config:
-        file: /etc/dex/db/dex.db
-    web:
-      http: 0.0.0.0:5556
-    oauth2:
-      skipApprovalScreen: false
-    logger:
-      level: "debug"
-
-    staticClients:
-    - id: authorino
-      name: 'Authorino'
-      redirectUris:
-      - http://localhost:3000/callback
-      secret: aaf88e0e-d41d-4325-a068-57c4b0d61d8e
-
-    enablePasswordDB: true
-    staticPasswords:
-    - email: "admin@localhost"
-      # bcrypt hash of the string "password"
-      hash: "$2a$10$2b2cU8CPhOTaGrs1HRQuAueS7JTT5ZHsHSzYiFPm1leZck7Mc8T4W"
-      username: "admin"
-      userID: "08a8684b-db88-4b73-90a9-3cd1661f5466"
 ---
 apiVersion: v1
 kind: Service

--- a/examples/envoy.yaml
+++ b/examples/envoy.yaml
@@ -1,80 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: envoy
-  labels:
-    app: authorino
-    svc: envoy
-spec:
-  selector:
-    matchLabels:
-      app: authorino
-      svc: envoy
-  template:
-    metadata:
-      labels:
-        app: authorino
-        svc: envoy
-    spec:
-      containers:
-        - name: envoy
-          image: envoyproxy/envoy:v1.17-latest
-          command: ["/usr/local/bin/envoy"]
-          args:
-            - --config-path /usr/local/etc/envoy/envoy.yaml
-            - --service-cluster front-proxy
-            - --log-level info
-            - --component-log-level filter:trace,http:debug,router:debug
-          ports:
-            - name: web
-              containerPort: 8000
-            - name: admin
-              containerPort: 8001
-          volumeMounts:
-            - name: config
-              mountPath: /usr/local/etc/envoy
-              readOnly: true
-      volumes:
-        - name: config
-          configMap:
-            name: envoy
-            items:
-              - key: envoy.yaml
-                path: envoy.yaml
-  replicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: envoy
-  labels:
-    app: authorino
-spec:
-  selector:
-    app: authorino
-    svc: envoy
-  ports:
-    - name: web
-      port: 8000
-      protocol: TCP
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
-metadata:
-  name: ingress-wildcard-host
-spec:
-  rules:
-    - host: "echo-api-authorino.127.0.0.1.nip.io"
-      http:
-        paths:
-          - pathType: Prefix
-            path: "/"
-            backend:
-              service:
-                name: envoy
-                port:
-                  number: 8000
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -157,4 +80,80 @@ data:
         socket_address:
           address: 0.0.0.0
           port_value: 8001
-
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: envoy
+  labels:
+    app: authorino
+    svc: envoy
+spec:
+  selector:
+    matchLabels:
+      app: authorino
+      svc: envoy
+  template:
+    metadata:
+      labels:
+        app: authorino
+        svc: envoy
+    spec:
+      containers:
+        - name: envoy
+          image: envoyproxy/envoy:v1.17-latest
+          command: ["/usr/local/bin/envoy"]
+          args:
+            - --config-path /usr/local/etc/envoy/envoy.yaml
+            - --service-cluster front-proxy
+            - --log-level info
+            - --component-log-level filter:trace,http:debug,router:debug
+          ports:
+            - name: web
+              containerPort: 8000
+            - name: admin
+              containerPort: 8001
+          volumeMounts:
+            - name: config
+              mountPath: /usr/local/etc/envoy
+              readOnly: true
+      volumes:
+        - name: config
+          configMap:
+            name: envoy
+            items:
+              - key: envoy.yaml
+                path: envoy.yaml
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: envoy
+  labels:
+    app: authorino
+spec:
+  selector:
+    app: authorino
+    svc: envoy
+  ports:
+    - name: web
+      port: 8000
+      protocol: TCP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-wildcard-host
+spec:
+  rules:
+    - host: "echo-api-authorino.127.0.0.1.nip.io"
+      http:
+        paths:
+          - pathType: Prefix
+            path: "/"
+            backend:
+              service:
+                name: envoy
+                port:
+                  number: 8000

--- a/examples/keycloak.yaml
+++ b/examples/keycloak.yaml
@@ -1,60 +1,3 @@
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: keycloak
-  labels:
-    app: keycloak
-spec:
-  selector:
-    matchLabels:
-      app: keycloak
-  template:
-    metadata:
-      labels:
-        app: keycloak
-    spec:
-      containers:
-        - name: keycloak
-          image: quay.io/keycloak/keycloak:12.0.3
-          env:
-            - name: KEYCLOAK_USER
-              value: admin
-            - name: KEYCLOAK_PASSWORD
-              value: p
-            - name: PROXY_ADDRESS_FORWARDING
-              value: "true"
-            - name: KEYCLOAK_IMPORT
-              value: /tmp/import-realm.json -Dkeycloak.profile.feature.upload_scripts=enabled
-          ports:
-            - name: auth
-              containerPort: 8080
-          volumeMounts:
-            - name: realm
-              mountPath: /tmp/
-              readOnly: true
-      volumes:
-        - name: realm
-          configMap:
-            name: keycloak-realm
-            items:
-              - key: import-realm.json
-                path: import-realm.json
-  replicas: 1
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: keycloak
-  labels:
-    app: keycloak
-spec:
-  selector:
-    app: keycloak
-  ports:
-    - name: keycloak
-      port: 8080
-      protocol: TCP
----
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -2395,3 +2338,60 @@ data:
       "keycloakVersion": "11.0.2",
       "userManagedAccessAllowed": true
     }
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  selector:
+    matchLabels:
+      app: keycloak
+  template:
+    metadata:
+      labels:
+        app: keycloak
+    spec:
+      containers:
+        - name: keycloak
+          image: quay.io/keycloak/keycloak:12.0.3
+          env:
+            - name: KEYCLOAK_USER
+              value: admin
+            - name: KEYCLOAK_PASSWORD
+              value: p
+            - name: PROXY_ADDRESS_FORWARDING
+              value: "true"
+            - name: KEYCLOAK_IMPORT
+              value: /tmp/import-realm.json -Dkeycloak.profile.feature.upload_scripts=enabled
+          ports:
+            - name: auth
+              containerPort: 8080
+          volumeMounts:
+            - name: realm
+              mountPath: /tmp/
+              readOnly: true
+      volumes:
+        - name: realm
+          configMap:
+            name: keycloak-realm
+            items:
+              - key: import-realm.json
+                path: import-realm.json
+  replicas: 1
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: keycloak
+  labels:
+    app: keycloak
+spec:
+  selector:
+    app: keycloak
+  ports:
+    - name: keycloak
+      port: 8080
+      protocol: TCP


### PR DESCRIPTION
Improves the performance of `make local-setup` by preloading images into the cluster whenever available in the local container registry. Otherwise, images such as keycloak image, envoy image and echo-api image will all be pulled again from the remote registries. In some cases (especially with bad internet connection), pulling those images from remote can take a long time, even causing the waiting for "all deployments to be up" to time out. If the tags are available locally, it is easier and faster just to load them into the cluster container registry. On the other hand, if any image is not available in the local registry, the script will not preload that image and kind will pull it (as before) from remote into the cluster registry.

The PR also introduces a new environment variable parameter `SKIP_BUILD`, which allows setting up the local cluster without re-building the authorino image. This in case all you want is to setup the environment with a version of the `authorino:devel` image that you have already tagged locally from before. Of course, if the local tag is missing, there is no fallback in this case and you should re-run the `make local-setup` command without setting the `SKIP_BUILD` env.