### PR TITLE
Fix make vendor target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,9 @@ manifests: controller-gen
 	$(CONTROLLER_GEN) $(CRD_OPTIONS) rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
 
 # Download vendor dependencies
+.PHONY: vendor
 vendor:
+	go mod tidy -v
 	go mod vendor -v
 
 # Run go fmt against code


### PR DESCRIPTION
We forgot to make the `vendor` target PHONY, so it was conflicting with the `/vendor` directory.

Also adding `go mod tidy -v` to it.