### PR TITLE
More enhancements to the examples page

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -341,6 +341,8 @@ curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN" http://local
 ----
 ## Multiple OIDC providers (Keycloak and Dex)
 
+The example sets two sources of identity to verify OIDC tokens (JWTs) – i.e., the Keycloak server and the Dex server, both running inside the cluster. If any of these providers accepts the token, Authorino succeeds in the identity verification phase.
+
 ### Deploy the example:
 
 ```sh
@@ -369,6 +371,12 @@ Dex user:
 export ACCESS_TOKEN_MARTA=$(curl -k -d 'grant_type=authorization_code' -d "code=<authorization-code>" -d 'client_id=demo' -d 'client_secret=aaf88e0e-d41d-4325-a068-57c4b0d61d8e' -d 'redirect_uri=http://localhost:3000/callback' "http://localhost:5556/token" | jq -r '.id_token')
 
 curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN_MARTA" http://localhost:8000/hello # 200
+```
+
+Invalid token (neither Keycloak, nor Dex will accept it):
+
+```sh
+curl -H 'Host: talker-api' -H 'Authorization: Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c' http://localhost:8000/hello # 403
 ```
 
 ----

--- a/examples/README.md
+++ b/examples/README.md
@@ -374,7 +374,7 @@ curl -H 'Host: talker-api' -H "Authorization: Bearer $ACCESS_TOKEN_MARTA" http:/
 ----
 ## Resource-level authorization (with UMA resource registry)
 
-The example uses Keycloak User-Managed Access (UMA) implementation hosting resource data, that is later fetched by Authorino on every request, in metadata phase.
+The example uses Keycloak User-Managed Access (UMA) implementation hosting resource data, that is later fetched by Authorino on every request, in metadata phase. See [Authorino architecture > User-Managed Access (UMA)](/docs/architecture.md#user-managed-access-uma) for more information.
 
 The Keycloak server also provides identities for OIDC authentication. The identity subject ("sub" claim) must match the owner of the requested resource, identitfied by the URI of the request.
 


### PR DESCRIPTION
- [x] Better instructions to 'Setup the environment' and avoid repeating the steps to deploy Keycloak
- [x] Replace the token revocation example with simpler OIDC end_session_endpoint
- [x] Link to Authorino-UMA architecture from the examples
- [x] Better description for the example 'Multiple OIDC providers (Keycloak and Dex)'