### PR TITLE
Reconciliation of deleted (API key) secrets

### DIFF
--- a/controllers/secret_controller.go
+++ b/controllers/secret_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/3scale-labs/authorino/api/v1beta1"
 	configv1beta1 "github.com/3scale-labs/authorino/api/v1beta1"
+	"github.com/3scale-labs/authorino/pkg/common"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -31,41 +32,101 @@ func (r *SecretReconciler) Reconcile(req ctrl.Request) (ctrl.Result, error) {
 	ctx := context.Background()
 	log := r.Log.WithValues("secret", req.NamespacedName)
 
+	var reconcile func(configv1beta1.Service)
+
 	secret := v1.Secret{}
 	if err := r.Client.Get(ctx, req.NamespacedName, &secret); err != nil && !errors.IsNotFound(err) {
+		// could not get the secret but not because of a 404 Not found (some error must have happened)
 		return ctrl.Result{}, err
-	}
 
-	// return if not an Authorino-watched secret
-	if _, watched := secret.Labels[authorinoWatchedSecretLabel]; !watched {
-		// FIXME: Authorino won't be able to fetch the secret's labels if the secret was deleted, so it will end up not reconciling the services anyway
-		return ctrl.Result{}, nil
-	}
+	} else if errors.IsNotFound(err) {
+		// could not find the secret: 404 Not found (secret must have been deleted)
+		// try to find a secret with same name by digging into the cache of services
+		reconcile = func(service configv1beta1.Service) {
+			for _, host := range service.Spec.Hosts {
+				sr, _ := r.ServiceReconciler.(*ServiceReconciler)
+				for _, id := range sr.Cache.Get(host).IdentityConfigs {
+					i, _ := id.(common.APIKeySecretFinder)
+					if s := i.FindSecretByName(req.NamespacedName); s != nil {
+						r.reconcileService(service)
+						return
+					}
+				}
+			}
+		}
 
-	var serviceList = &configv1beta1.ServiceList{}
-	if err := r.List(ctx, serviceList); err != nil {
-		log.Info("could not fetch list of services", "object", req)
-		return ctrl.Result{}, nil
 	} else {
-		for _, service := range serviceList.Items {
+		// found the secret
+
+		// return if not an Authorino-watched secret
+		if _, watched := secret.Labels[authorinoWatchedSecretLabel]; !watched {
+			return ctrl.Result{}, nil
+		}
+
+		// straightforward – if the API key labels match, reconcile the service
+		reconcile = func(service configv1beta1.Service) {
 			for _, id := range service.Spec.Identity {
 				if id.GetType() == v1beta1.IdentityApiKey && reflect.DeepEqual(id.APIKey.LabelSelectors, secret.Labels) {
-					_, _ = r.ServiceReconciler.Reconcile(ctrl.Request{
-						NamespacedName: types.NamespacedName{
-							Namespace: service.Namespace,
-							Name:      service.Name,
-						},
-					})
+					r.reconcileService(service)
+					return
 				}
 			}
 		}
 	}
 
-	return ctrl.Result{}, nil
+	if err := r.reconcileServicesUsingAPIKey(ctx, reconcile); err != nil {
+		log.Info("could not reconcile services", "req", req)
+		return ctrl.Result{}, err
+	} else {
+		return ctrl.Result{}, nil
+	}
 }
 
 func (r *SecretReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1.Secret{}).
 		Complete(r)
+}
+
+func (r *SecretReconciler) getServicesUsingAPIKey(ctx context.Context) ([]configv1beta1.Service, error) {
+	var existingServices = &configv1beta1.ServiceList{}
+	selectedServices := make([]configv1beta1.Service, 0)
+
+	if err := r.List(ctx, existingServices); err != nil {
+		return nil, err
+	} else {
+		for _, service := range existingServices.Items {
+			for _, id := range service.Spec.Identity {
+				if id.GetType() == v1beta1.IdentityApiKey {
+					selectedServices = append(selectedServices, service)
+					break
+				}
+			}
+		}
+		return selectedServices, nil
+	}
+}
+
+// reconcileServicesUsingAPIKey invokes the reconcile(service) func asynchronously, for each service using API key identity
+func (r *SecretReconciler) reconcileServicesUsingAPIKey(ctx context.Context, reconcile func(configv1beta1.Service)) error {
+	if services, err := r.getServicesUsingAPIKey(ctx); err != nil {
+		return err
+	} else {
+		for _, service := range services {
+			s := service
+			go func() {
+				reconcile(s)
+			}()
+		}
+		return nil
+	}
+}
+
+func (r *SecretReconciler) reconcileService(service configv1beta1.Service) {
+	_, _ = r.ServiceReconciler.Reconcile(ctrl.Request{
+		NamespacedName: types.NamespacedName{
+			Namespace: service.Namespace,
+			Name:      service.Name,
+		},
+	})
 }

--- a/pkg/common/auth.go
+++ b/pkg/common/auth.go
@@ -4,6 +4,8 @@ import (
 	"golang.org/x/net/context"
 
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 type AuthPipeline interface {
@@ -27,4 +29,8 @@ type NamedConfigEvaluator interface {
 
 type IdentityConfigEvaluator interface {
 	GetOIDC() interface{}
+}
+
+type APIKeySecretFinder interface {
+	FindSecretByName(types.NamespacedName) *v1.Secret
 }

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -6,6 +6,9 @@ import (
 
 	"github.com/3scale-labs/authorino/pkg/common"
 	"github.com/3scale-labs/authorino/pkg/config/identity"
+
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 var (
@@ -50,4 +53,17 @@ func (config *IdentityConfig) Call(pipeline common.AuthPipeline, ctx context.Con
 
 func (config *IdentityConfig) GetOIDC() interface{} {
 	return config.OIDC
+}
+
+func (config *IdentityConfig) GetAPIKey() interface{} {
+	return config.APIKey
+}
+
+func (config *IdentityConfig) FindSecretByName(lookup types.NamespacedName) *v1.Secret {
+	apiKey := config.APIKey
+	if apiKey != nil {
+		return apiKey.FindSecretByName(lookup)
+	} else {
+		return nil
+	}
 }

--- a/pkg/config/identity/api_key.go
+++ b/pkg/config/identity/api_key.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/3scale-labs/authorino/pkg/common"
@@ -92,4 +93,13 @@ func (apiKey *APIKey) Call(pipeline common.AuthPipeline, _ context.Context) (int
 	err := fmt.Errorf(invalidApiKeyMsg)
 	apiKeyLog.Error(err, invalidApiKeyMsg)
 	return nil, err
+}
+
+func (apiKey *APIKey) FindSecretByName(lookup types.NamespacedName) *v1.Secret {
+	for _, secret := range apiKey.authorizedCredentials {
+		if secret.GetNamespace() == lookup.Namespace && secret.GetName() == lookup.Name {
+			return &secret
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Since the controller cannot find secrets that have been deleted, all it has to trigger reconciliation of affected services is the namespaced name of the deleted secret. So in this case of reconciliation of delete secrets, Authorino will dig into the cache of services looking for any service whose API key identity config has cached the deleted secret as an "authorized credential". These services will be reconciled.

For the already supported cases (create secret and update secret, the only change is that service reconciliation is now triggered inside a goroutine.

----

**Verification steps:**
1. Deploy a service with API key authentication
2. Create a secret that represents a valid API key for the service deployed
3. Send requests to the API using the API key to authenticate
4. Verify that authentication succeeds (you get a `200 OK` response)
5. Delete the secret crested before
6. Send requests again to the API
7. Verify that authentication now fails (you get a `403 Forbidden` response)