### PR TITLE
Rename AuthContext to AuthPipeline

### DIFF
--- a/pkg/cache/cache_test.go
+++ b/pkg/cache/cache_test.go
@@ -11,7 +11,7 @@ import (
 
 type BogusIdentity struct{}
 
-func (f *BogusIdentity) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (f *BogusIdentity) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	return true, nil
 }
 

--- a/pkg/common/auth.go
+++ b/pkg/common/auth.go
@@ -6,7 +6,7 @@ import (
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 )
 
-type AuthContext interface {
+type AuthPipeline interface {
 	GetParentContext() *context.Context
 	GetRequest() *envoy_auth.CheckRequest
 	GetHttp() *envoy_auth.AttributeContext_HttpRequest
@@ -18,7 +18,7 @@ type AuthContext interface {
 
 // AuthConfigEvaluator interface represents the configuration pieces of Identity, Metadata and Authorization
 type AuthConfigEvaluator interface {
-	Call(AuthContext, context.Context) (interface{}, error)
+	Call(AuthPipeline, context.Context) (interface{}, error)
 }
 
 type NamedConfigEvaluator interface {

--- a/pkg/common/mocks/mock_common.go
+++ b/pkg/common/mocks/mock_common.go
@@ -13,31 +13,31 @@ import (
 	context "golang.org/x/net/context"
 )
 
-// MockAuthContext is a mock of AuthContext interface.
-type MockAuthContext struct {
+// MockAuthPipeline is a mock of AuthPipeline interface.
+type MockAuthPipeline struct {
 	ctrl     *gomock.Controller
-	recorder *MockAuthContextMockRecorder
+	recorder *MockAuthPipelineMockRecorder
 }
 
-// MockAuthContextMockRecorder is the mock recorder for MockAuthContext.
-type MockAuthContextMockRecorder struct {
-	mock *MockAuthContext
+// MockAuthPipelineMockRecorder is the mock recorder for MockAuthPipeline.
+type MockAuthPipelineMockRecorder struct {
+	mock *MockAuthPipeline
 }
 
-// NewMockAuthContext creates a new mock instance.
-func NewMockAuthContext(ctrl *gomock.Controller) *MockAuthContext {
-	mock := &MockAuthContext{ctrl: ctrl}
-	mock.recorder = &MockAuthContextMockRecorder{mock}
+// NewMockAuthPipeline creates a new mock instance.
+func NewMockAuthPipeline(ctrl *gomock.Controller) *MockAuthPipeline {
+	mock := &MockAuthPipeline{ctrl: ctrl}
+	mock.recorder = &MockAuthPipelineMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use.
-func (m *MockAuthContext) EXPECT() *MockAuthContextMockRecorder {
+func (m *MockAuthPipeline) EXPECT() *MockAuthPipelineMockRecorder {
 	return m.recorder
 }
 
 // GetAPI mocks base method.
-func (m *MockAuthContext) GetAPI() interface{} {
+func (m *MockAuthPipeline) GetAPI() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAPI")
 	ret0, _ := ret[0].(interface{})
@@ -45,13 +45,13 @@ func (m *MockAuthContext) GetAPI() interface{} {
 }
 
 // GetAPI indicates an expected call of GetAPI.
-func (mr *MockAuthContextMockRecorder) GetAPI() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetAPI() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPI", reflect.TypeOf((*MockAuthContext)(nil).GetAPI))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPI", reflect.TypeOf((*MockAuthPipeline)(nil).GetAPI))
 }
 
 // GetDataForAuthorization mocks base method.
-func (m *MockAuthContext) GetDataForAuthorization() interface{} {
+func (m *MockAuthPipeline) GetDataForAuthorization() interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDataForAuthorization")
 	ret0, _ := ret[0].(interface{})
@@ -59,13 +59,13 @@ func (m *MockAuthContext) GetDataForAuthorization() interface{} {
 }
 
 // GetDataForAuthorization indicates an expected call of GetDataForAuthorization.
-func (mr *MockAuthContextMockRecorder) GetDataForAuthorization() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetDataForAuthorization() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataForAuthorization", reflect.TypeOf((*MockAuthContext)(nil).GetDataForAuthorization))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDataForAuthorization", reflect.TypeOf((*MockAuthPipeline)(nil).GetDataForAuthorization))
 }
 
 // GetHttp mocks base method.
-func (m *MockAuthContext) GetHttp() *envoy_service_auth_v3.AttributeContext_HttpRequest {
+func (m *MockAuthPipeline) GetHttp() *envoy_service_auth_v3.AttributeContext_HttpRequest {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetHttp")
 	ret0, _ := ret[0].(*envoy_service_auth_v3.AttributeContext_HttpRequest)
@@ -73,13 +73,13 @@ func (m *MockAuthContext) GetHttp() *envoy_service_auth_v3.AttributeContext_Http
 }
 
 // GetHttp indicates an expected call of GetHttp.
-func (mr *MockAuthContextMockRecorder) GetHttp() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetHttp() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHttp", reflect.TypeOf((*MockAuthContext)(nil).GetHttp))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetHttp", reflect.TypeOf((*MockAuthPipeline)(nil).GetHttp))
 }
 
 // GetParentContext mocks base method.
-func (m *MockAuthContext) GetParentContext() *context.Context {
+func (m *MockAuthPipeline) GetParentContext() *context.Context {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetParentContext")
 	ret0, _ := ret[0].(*context.Context)
@@ -87,13 +87,13 @@ func (m *MockAuthContext) GetParentContext() *context.Context {
 }
 
 // GetParentContext indicates an expected call of GetParentContext.
-func (mr *MockAuthContextMockRecorder) GetParentContext() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetParentContext() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParentContext", reflect.TypeOf((*MockAuthContext)(nil).GetParentContext))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetParentContext", reflect.TypeOf((*MockAuthPipeline)(nil).GetParentContext))
 }
 
 // GetRequest mocks base method.
-func (m *MockAuthContext) GetRequest() *envoy_service_auth_v3.CheckRequest {
+func (m *MockAuthPipeline) GetRequest() *envoy_service_auth_v3.CheckRequest {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRequest")
 	ret0, _ := ret[0].(*envoy_service_auth_v3.CheckRequest)
@@ -101,13 +101,13 @@ func (m *MockAuthContext) GetRequest() *envoy_service_auth_v3.CheckRequest {
 }
 
 // GetRequest indicates an expected call of GetRequest.
-func (mr *MockAuthContextMockRecorder) GetRequest() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetRequest() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequest", reflect.TypeOf((*MockAuthContext)(nil).GetRequest))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRequest", reflect.TypeOf((*MockAuthPipeline)(nil).GetRequest))
 }
 
 // GetResolvedIdentity mocks base method.
-func (m *MockAuthContext) GetResolvedIdentity() (interface{}, interface{}) {
+func (m *MockAuthPipeline) GetResolvedIdentity() (interface{}, interface{}) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResolvedIdentity")
 	ret0, _ := ret[0].(interface{})
@@ -116,13 +116,13 @@ func (m *MockAuthContext) GetResolvedIdentity() (interface{}, interface{}) {
 }
 
 // GetResolvedIdentity indicates an expected call of GetResolvedIdentity.
-func (mr *MockAuthContextMockRecorder) GetResolvedIdentity() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetResolvedIdentity() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedIdentity", reflect.TypeOf((*MockAuthContext)(nil).GetResolvedIdentity))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedIdentity", reflect.TypeOf((*MockAuthPipeline)(nil).GetResolvedIdentity))
 }
 
 // GetResolvedMetadata mocks base method.
-func (m *MockAuthContext) GetResolvedMetadata() map[interface{}]interface{} {
+func (m *MockAuthPipeline) GetResolvedMetadata() map[interface{}]interface{} {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetResolvedMetadata")
 	ret0, _ := ret[0].(map[interface{}]interface{})
@@ -130,9 +130,9 @@ func (m *MockAuthContext) GetResolvedMetadata() map[interface{}]interface{} {
 }
 
 // GetResolvedMetadata indicates an expected call of GetResolvedMetadata.
-func (mr *MockAuthContextMockRecorder) GetResolvedMetadata() *gomock.Call {
+func (mr *MockAuthPipelineMockRecorder) GetResolvedMetadata() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedMetadata", reflect.TypeOf((*MockAuthContext)(nil).GetResolvedMetadata))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetResolvedMetadata", reflect.TypeOf((*MockAuthPipeline)(nil).GetResolvedMetadata))
 }
 
 // MockAuthConfigEvaluator is a mock of AuthConfigEvaluator interface.
@@ -159,7 +159,7 @@ func (m *MockAuthConfigEvaluator) EXPECT() *MockAuthConfigEvaluatorMockRecorder 
 }
 
 // Call mocks base method.
-func (m *MockAuthConfigEvaluator) Call(arg0 common.AuthContext, arg1 context.Context) (interface{}, error) {
+func (m *MockAuthConfigEvaluator) Call(arg0 common.AuthPipeline, arg1 context.Context) (interface{}, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Call", arg0, arg1)
 	ret0, _ := ret[0].(interface{})

--- a/pkg/config/authorization.go
+++ b/pkg/config/authorization.go
@@ -19,12 +19,12 @@ type AuthorizationConfig struct {
 	JSON *authorization.JSONPatternMatching `yaml:"json,omitempty"`
 }
 
-func (config *AuthorizationConfig) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (config *AuthorizationConfig) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	switch {
 	case config.OPA != nil:
-		return config.OPA.Call(authContext, ctx)
+		return config.OPA.Call(pipeline, ctx)
 	case config.JSON != nil:
-		return config.JSON.Call(authContext, ctx)
+		return config.JSON.Call(pipeline, ctx)
 	default:
 		return false, fmt.Errorf("invalid authorization configs")
 	}

--- a/pkg/config/authorization/json.go
+++ b/pkg/config/authorization/json.go
@@ -32,8 +32,8 @@ type JSONPatternMatching struct {
 	Rules      []JSONPatternMatchingRule `yaml:"rules"`
 }
 
-func (jsonAuth *JSONPatternMatching) Call(authContext common.AuthContext, ctx context.Context) (bool, error) {
-	data := authContext.GetDataForAuthorization()
+func (jsonAuth *JSONPatternMatching) Call(pipeline common.AuthPipeline, ctx context.Context) (bool, error) {
+	data := pipeline.GetDataForAuthorization()
 	dataJSON, _ := json.Marshal(data)
 	dataStr := string(dataJSON)
 

--- a/pkg/config/authorization/json_test.go
+++ b/pkg/config/authorization/json_test.go
@@ -37,8 +37,8 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
-	authContextMock.EXPECT().GetDataForAuthorization().Return(dataForAuthorization).AnyTimes()
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
+	pipelineMock.EXPECT().GetDataForAuthorization().Return(dataForAuthorization).AnyTimes()
 
 	var (
 		jsonAuth   *JSONPatternMatching
@@ -57,7 +57,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -72,7 +72,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -87,7 +87,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -102,7 +102,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -117,7 +117,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -132,7 +132,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -147,7 +147,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -162,7 +162,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -177,7 +177,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -192,7 +192,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -207,7 +207,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.ErrorContains(t, err, "error parsing regexp")
 
@@ -242,7 +242,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -277,7 +277,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -286,7 +286,7 @@ func TestCall(t *testing.T) {
 		Rules: []JSONPatternMatchingRule{},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -308,7 +308,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 
@@ -330,7 +330,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, !authorized)
 	assert.Error(t, err, "Unauthorized")
 
@@ -352,7 +352,7 @@ func TestCall(t *testing.T) {
 		},
 	}
 
-	authorized, err = jsonAuth.Call(authContextMock, nil)
+	authorized, err = jsonAuth.Call(pipelineMock, nil)
 	assert.Check(t, authorized)
 	assert.Check(t, err == nil)
 }

--- a/pkg/config/authorization/opa.go
+++ b/pkg/config/authorization/opa.go
@@ -48,8 +48,8 @@ type OPA struct {
 	policyUID  string
 }
 
-func (opa *OPA) Call(authContext common.AuthContext, ctx context.Context) (bool, error) {
-	options := rego.EvalInput(authContext.GetDataForAuthorization())
+func (opa *OPA) Call(pipeline common.AuthPipeline, ctx context.Context) (bool, error) {
+	options := rego.EvalInput(pipeline.GetDataForAuthorization())
 	results, err := opa.policy.Eval(opa.opaContext, options)
 
 	if err != nil {

--- a/pkg/config/identity.go
+++ b/pkg/config/identity.go
@@ -29,20 +29,20 @@ func init() {
 }
 
 // Call method will execute the specific Identity implementation's method
-func (config *IdentityConfig) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (config *IdentityConfig) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	switch {
 	case config.OAuth2 != nil:
-		return config.OAuth2.Call(authContext, ctx)
+		return config.OAuth2.Call(pipeline, ctx)
 	case config.OIDC != nil:
-		return config.OIDC.Call(authContext, ctx)
+		return config.OIDC.Call(pipeline, ctx)
 	case config.MTLS != nil:
-		return config.MTLS.Call(authContext, ctx)
+		return config.MTLS.Call(pipeline, ctx)
 	case config.HMAC != nil:
-		return config.HMAC.Call(authContext, ctx)
+		return config.HMAC.Call(pipeline, ctx)
 	case config.APIKey != nil:
-		return config.APIKey.Call(authContext, ctx)
+		return config.APIKey.Call(pipeline, ctx)
 	case config.KubernetesAuth != nil:
-		return config.KubernetesAuth.Call(authContext, ctx)
+		return config.KubernetesAuth.Call(pipeline, ctx)
 	default:
 		return "", fmt.Errorf("invalid identity config")
 	}

--- a/pkg/config/identity/api_key.go
+++ b/pkg/config/identity/api_key.go
@@ -23,7 +23,7 @@ const (
 // APIKeyIdentityEvaluator interface represents the API Key Identity evaluator
 type APIKeyIdentityEvaluator interface {
 	GetCredentialsFromCluster(context.Context) error
-	Call(common.AuthContext, context.Context) (interface{}, error)
+	Call(common.AuthPipeline, context.Context) (interface{}, error)
 }
 
 type apiKeyDetails struct {
@@ -77,8 +77,8 @@ func (apiKey *APIKey) GetCredentialsFromCluster(ctx context.Context) error {
 }
 
 // Call will evaluate the credentials within the request against the authorized ones
-func (apiKey *APIKey) Call(authCtx common.AuthContext, _ context.Context) (interface{}, error) {
-	if reqKey, err := apiKey.GetCredentialsFromReq(authCtx.GetHttp()); err != nil {
+func (apiKey *APIKey) Call(pipeline common.AuthPipeline, _ context.Context) (interface{}, error) {
+	if reqKey, err := apiKey.GetCredentialsFromReq(pipeline.GetHttp()); err != nil {
 		apiKeyLog.Error(err, noApiKeysFoundMsg)
 		return nil, err
 	} else {

--- a/pkg/config/identity/hmac.go
+++ b/pkg/config/identity/hmac.go
@@ -10,6 +10,6 @@ type HMAC struct {
 	Secret string `yaml:"secret"`
 }
 
-func (self *HMAC) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (self *HMAC) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	return "Authenticated with HMAC", nil // TODO: implement
 }

--- a/pkg/config/identity/kubernetes_auth.go
+++ b/pkg/config/identity/kubernetes_auth.go
@@ -51,12 +51,12 @@ func NewKubernetesAuthIdentity(authCred auth_credentials.AuthCredentials, audien
 	}, nil
 }
 
-func (kubeAuth *KubernetesAuth) Call(authCtx common.AuthContext, ctx context.Context) (interface{}, error) {
+func (kubeAuth *KubernetesAuth) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	if err := common.CheckContext(ctx); err != nil {
 		return nil, err
 	}
 
-	request := authCtx.GetHttp()
+	request := pipeline.GetHttp()
 	if reqToken, err := kubeAuth.GetCredentialsFromReq(request); err != nil {
 		return nil, err
 	} else {

--- a/pkg/config/identity/kubernetes_auth_test.go
+++ b/pkg/config/identity/kubernetes_auth_test.go
@@ -91,14 +91,14 @@ func TestAuthenticatedToken(t *testing.T) {
 	defer ctrl.Finish()
 
 	authCredsMock := mock_auth_credentials.NewMockAuthCredentials(ctrl)
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	authContextMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
 	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, true, []string{"echo-api"}})
-	ret, err := kubernetesAuth.Call(authContextMock, context.TODO())
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.NilError(t, err)
 
@@ -113,14 +113,14 @@ func TestUnauthenticatedToken(t *testing.T) {
 	defer ctrl.Finish()
 
 	authCredsMock := mock_auth_credentials.NewMockAuthCredentials(ctrl)
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	authContextMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
 	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, false, []string{"echo-api"}})
-	ret, err := kubernetesAuth.Call(authContextMock, context.TODO())
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.Check(t, ret == nil)
 	assert.Error(t, err, "Not authenticated")
@@ -134,14 +134,14 @@ func TestOpaqueToken(t *testing.T) {
 	defer ctrl.Finish()
 
 	authCredsMock := mock_auth_credentials.NewMockAuthCredentials(ctrl)
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	authContextMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
 	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{}, tokenReviewData{requestToken, true, []string{"echo-api"}})
-	ret, err := kubernetesAuth.Call(authContextMock, context.TODO())
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.NilError(t, err)
 
@@ -157,14 +157,14 @@ func TestCustomAudiences(t *testing.T) {
 	defer ctrl.Finish()
 
 	authCredsMock := mock_auth_credentials.NewMockAuthCredentials(ctrl)
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	authContextMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
 	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{"custom-audience"}, tokenReviewData{requestToken, true, []string{"custom-audience"}})
-	ret, err := kubernetesAuth.Call(authContextMock, context.TODO())
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.NilError(t, err)
 
@@ -179,14 +179,14 @@ func TestCustomAudiencesUnmatch(t *testing.T) {
 	defer ctrl.Finish()
 
 	authCredsMock := mock_auth_credentials.NewMockAuthCredentials(ctrl)
-	authContextMock := mock_common.NewMockAuthContext(ctrl)
+	pipelineMock := mock_common.NewMockAuthPipeline(ctrl)
 
 	request := &envoy_auth.AttributeContext_HttpRequest{Host: "echo-api"}
-	authContextMock.EXPECT().GetHttp().Return(request).AnyTimes()
+	pipelineMock.EXPECT().GetHttp().Return(request).AnyTimes()
 	authCredsMock.EXPECT().GetCredentialsFromReq(request).Return(requestToken, nil)
 
 	kubernetesAuth := newKubernetesAuth(authCredsMock, []string{"expected-audience"}, tokenReviewData{requestToken, false, []string{"custom-audience"}})
-	ret, err := kubernetesAuth.Call(authContextMock, context.TODO())
+	ret, err := kubernetesAuth.Call(pipelineMock, context.TODO())
 
 	assert.Check(t, ret == nil)
 	assert.Error(t, err, "Not authenticated")

--- a/pkg/config/identity/mtls.go
+++ b/pkg/config/identity/mtls.go
@@ -10,6 +10,6 @@ type MTLS struct {
 	PEM string `yaml:"pem"`
 }
 
-func (self *MTLS) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (self *MTLS) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	return "Authenticated with mTLS", nil // TODO: implement
 }

--- a/pkg/config/identity/oauth2.go
+++ b/pkg/config/identity/oauth2.go
@@ -37,13 +37,13 @@ func NewOAuth2Identity(tokenIntrospectionUrl string, tokenTypeHint string, clien
 	}
 }
 
-func (oauth *OAuth2) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (oauth *OAuth2) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	if err := common.CheckContext(ctx); err != nil {
 		return nil, err
 	}
 
 	// retrieve access token
-	accessToken, err := oauth.Credentials.GetCredentialsFromReq(authContext.GetHttp())
+	accessToken, err := oauth.Credentials.GetCredentialsFromReq(pipeline.GetHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/identity/oauth2_test.go
+++ b/pkg/config/identity/oauth2_test.go
@@ -28,14 +28,14 @@ func TestOAuth2Call(t *testing.T) {
 	authCredMock := NewMockAuthCredentials(ctrl)
 	authCredMock.EXPECT().GetCredentialsFromReq(Any()).Return("oauth-opaque-token", nil).AnyTimes()
 
-	authContextMock := NewMockAuthContext(ctrl)
-	authContextMock.EXPECT().GetHttp().Return(nil).AnyTimes()
+	pipelineMock := NewMockAuthPipeline(ctrl)
+	pipelineMock.EXPECT().GetHttp().Return(nil).AnyTimes()
 
 	ctx := context.Background()
 
 	{
 		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-active", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
-		obj, err := oauthEvaluator.Call(authContextMock, ctx)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
 		assert.NilError(t, err)
 		claims := obj.(map[string]interface{})
 		assert.Assert(t, claims["active"])
@@ -43,7 +43,7 @@ func TestOAuth2Call(t *testing.T) {
 
 	{
 		oauthEvaluator := NewOAuth2Identity(fmt.Sprintf("http://%v/introspect-inactive", oauthServerHost), "access_token", "client-id", "client-secret", authCredMock)
-		obj, err := oauthEvaluator.Call(authContextMock, ctx)
+		obj, err := oauthEvaluator.Call(pipelineMock, ctx)
 		assert.NilError(t, err)
 		claims := obj.(map[string]interface{})
 		assert.Assert(t, claims["active"] == false)

--- a/pkg/config/identity/oidc.go
+++ b/pkg/config/identity/oidc.go
@@ -29,9 +29,9 @@ func NewOIDC(endpoint string, creds auth_credentials.AuthCredentials) (*OIDC, er
 	}
 }
 
-func (oidc *OIDC) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (oidc *OIDC) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	// retrieve access token
-	accessToken, err := oidc.Credentials.GetCredentialsFromReq(authContext.GetRequest().GetAttributes().GetRequest().GetHttp())
+	accessToken, err := oidc.Credentials.GetCredentialsFromReq(pipeline.GetRequest().GetAttributes().GetRequest().GetHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/metadata.go
+++ b/pkg/config/metadata.go
@@ -23,13 +23,13 @@ func init() {
 	MetadataEvaluator = &MetadataConfig{}
 }
 
-func (config *MetadataConfig) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (config *MetadataConfig) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	t, _ := config.GetType()
 	switch t {
 	case "userinfo":
-		return config.UserInfo.Call(authContext, ctx)
+		return config.UserInfo.Call(pipeline, ctx)
 	case "uma":
-		return config.UMA.Call(authContext, ctx)
+		return config.UMA.Call(pipeline, ctx)
 	default:
 		return "", fmt.Errorf("invalid metadata config")
 	}

--- a/pkg/config/metadata/uma.go
+++ b/pkg/config/metadata/uma.go
@@ -187,7 +187,7 @@ func (uma *UMA) discover() error {
 	}
 }
 
-func (uma *UMA) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (uma *UMA) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	// get the protection API token (PAT)
 	var pat PAT
 	if err := uma.requestPAT(ctx, &pat); err != nil {
@@ -195,7 +195,7 @@ func (uma *UMA) Call(authContext common.AuthContext, ctx context.Context) (inter
 	}
 
 	// get resource data
-	uri := authContext.GetHttp().GetPath()
+	uri := pipeline.GetHttp().GetPath()
 	resourceData, err := uma.provider.GetResourcesByURI(uri, pat, ctx)
 
 	if err != nil {

--- a/pkg/config/metadata/uma_test.go
+++ b/pkg/config/metadata/uma_test.go
@@ -69,13 +69,13 @@ func TestUMACall(t *testing.T) {
 	ctrl := NewController(t)
 	defer ctrl.Finish()
 
-	authContextMock := NewMockAuthContext(ctrl)
+	pipelineMock := NewMockAuthPipeline(ctrl)
 	request := &envoy_auth.AttributeContext_HttpRequest{Path: "/someresource"}
-	authContextMock.EXPECT().GetHttp().Return(request)
+	pipelineMock.EXPECT().GetHttp().Return(request)
 
 	uma, _ := NewUMAMetadata(umaIssuer, "client-id", "client-secret")
 
-	obj, err := uma.Call(authContextMock, context.TODO())
+	obj, err := uma.Call(pipelineMock, context.TODO())
 
 	data, _ := json.Marshal(obj)
 	assert.Equal(t, "["+resourceData+"]", string(data))

--- a/pkg/config/metadata/user_info.go
+++ b/pkg/config/metadata/user_info.go
@@ -14,18 +14,18 @@ type UserInfo struct {
 	OIDC *identity.OIDC `yaml:"oidc,omitempty"`
 }
 
-func (userinfo *UserInfo) Call(authContext common.AuthContext, ctx context.Context) (interface{}, error) {
+func (userinfo *UserInfo) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	oidc := userinfo.OIDC
 
 	// check if corresponding oidc identity was resolved
-	resolvedIdentity, _ := authContext.GetResolvedIdentity()
+	resolvedIdentity, _ := pipeline.GetResolvedIdentity()
 	identityEvaluator, _ := resolvedIdentity.(common.IdentityConfigEvaluator)
 	if resolvedOIDC, _ := identityEvaluator.GetOIDC().(*identity.OIDC); resolvedOIDC == nil || resolvedOIDC.Endpoint != oidc.Endpoint {
 		return nil, fmt.Errorf("Missing identity for OIDC issuer %v. Skipping related UserInfo metadata.", oidc.Endpoint)
 	}
 
 	// get access token from input
-	accessToken, err := oidc.Credentials.GetCredentialsFromReq(authContext.GetHttp())
+	accessToken, err := oidc.Credentials.GetCredentialsFromReq(pipeline.GetHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/service/auth.go
+++ b/pkg/service/auth.go
@@ -49,9 +49,9 @@ func (self *AuthService) Check(ctx context.Context, req *envoy_auth.CheckRequest
 		return self.deniedResponse(rpc.NOT_FOUND, "Service not found"), nil
 	}
 
-	authContext := NewAuthContext(ctx, req, apiConfig)
+	pipeline := NewAuthPipeline(ctx, req, apiConfig)
 
-	err = authContext.Evaluate()
+	err = pipeline.Evaluate()
 	if err != nil {
 		return self.deniedResponse(rpc.PERMISSION_DENIED, err.Error()), nil
 	}

--- a/pkg/service/auth_pipeline.go
+++ b/pkg/service/auth_pipeline.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	authCtxLog = ctrl.Log.WithName("Authorino").WithName("AuthContext")
+	authCtxLog = ctrl.Log.WithName("Authorino").WithName("AuthPipeline")
 )
 
 type EvaluationResponse struct {
@@ -32,10 +32,10 @@ func newEvaluationResponse(evaluator common.AuthConfigEvaluator, obj interface{}
 	}
 }
 
-// AuthContext holds the context of each auth request, including the request itself (sent by the client),
-// the auth config of the requested API and the lists of identity verifications, metadata add-ons and
-// authorization policies, and their corresponding results after evaluated
-type AuthContext struct {
+// AuthPipeline evaluates the context of an auth request upon the auth configs defined for the requested API
+// Throughout the pipeline, user identity, adhoc metadata and authorization policies are evaluated and their
+// corresponding resulting objects stored in the respective maps.
+type AuthPipeline struct {
 	ParentContext *context.Context
 	Request       *envoy_auth.CheckRequest
 	API           *config.APIConfig
@@ -45,10 +45,9 @@ type AuthContext struct {
 	Authorization map[*config.AuthorizationConfig]interface{}
 }
 
-// NewAuthContext creates an AuthContext instance
-func NewAuthContext(parentCtx context.Context, req *envoy_auth.CheckRequest, apiConfig config.APIConfig) AuthContext {
-
-	return AuthContext{
+// NewAuthPipeline creates an AuthPipeline instance
+func NewAuthPipeline(parentCtx context.Context, req *envoy_auth.CheckRequest, apiConfig config.APIConfig) AuthPipeline {
+	return AuthPipeline{
 		ParentContext: &parentCtx,
 		Request:       req,
 		API:           &apiConfig,
@@ -56,16 +55,15 @@ func NewAuthContext(parentCtx context.Context, req *envoy_auth.CheckRequest, api
 		Metadata:      make(map[*config.MetadataConfig]interface{}),
 		Authorization: make(map[*config.AuthorizationConfig]interface{}),
 	}
-
 }
 
-func (authContext *AuthContext) evaluateAuthConfig(config common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, successCallback func(), failureCallback func()) {
+func (pipeline *AuthPipeline) evaluateAuthConfig(config common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, successCallback func(), failureCallback func()) {
 	if err := common.CheckContext(ctx); err != nil {
 		authCtxLog.Info("Skipping auth config", "config", config, "reason", err)
 		return
 	}
 
-	if authObj, err := config.Call(authContext, ctx); err != nil {
+	if authObj, err := config.Call(pipeline, ctx); err != nil {
 		*respChannel <- newEvaluationResponse(config, nil, err)
 
 		authCtxLog.Info("Failed to evaluate auth object", "config", config, "error", err)
@@ -84,8 +82,8 @@ func (authContext *AuthContext) evaluateAuthConfig(config common.AuthConfigEvalu
 
 type authConfigEvaluationStrategy func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, cancel func())
 
-func (authContext *AuthContext) evaluateAuthConfigs(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse, es authConfigEvaluationStrategy) {
-	ctx, cancel := context.WithCancel(*authContext.ParentContext)
+func (pipeline *AuthPipeline) evaluateAuthConfigs(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse, es authConfigEvaluationStrategy) {
+	ctx, cancel := context.WithCancel(*pipeline.ParentContext)
 	waitGroup := new(sync.WaitGroup)
 	waitGroup.Add(len(authConfigs))
 
@@ -101,31 +99,31 @@ func (authContext *AuthContext) evaluateAuthConfigs(authConfigs []common.AuthCon
 	waitGroup.Wait()
 }
 
-func (authContext *AuthContext) evaluateOneAuthConfig(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
-	authContext.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, cancel func()) {
-		authContext.evaluateAuthConfig(conf, ctx, respChannel, cancel, nil) // cancels the context if at least one thread succeeds
+func (pipeline *AuthPipeline) evaluateOneAuthConfig(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
+	pipeline.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, cancel func()) {
+		pipeline.evaluateAuthConfig(conf, ctx, respChannel, cancel, nil) // cancels the context if at least one thread succeeds
 	})
 }
 
-func (authContext *AuthContext) evaluateAllAuthConfigs(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
-	authContext.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, cancel func()) {
-		authContext.evaluateAuthConfig(conf, ctx, respChannel, nil, cancel) // cancels the context if at least one thread fails
+func (pipeline *AuthPipeline) evaluateAllAuthConfigs(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
+	pipeline.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, cancel func()) {
+		pipeline.evaluateAuthConfig(conf, ctx, respChannel, nil, cancel) // cancels the context if at least one thread fails
 	})
 }
 
-func (authContext *AuthContext) evaluateAnyAuthConfig(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
-	authContext.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, _ func()) {
-		authContext.evaluateAuthConfig(conf, ctx, respChannel, nil, nil)
+func (pipeline *AuthPipeline) evaluateAnyAuthConfig(authConfigs []common.AuthConfigEvaluator, respChannel *chan EvaluationResponse) {
+	pipeline.evaluateAuthConfigs(authConfigs, respChannel, func(conf common.AuthConfigEvaluator, ctx context.Context, respChannel *chan EvaluationResponse, _ func()) {
+		pipeline.evaluateAuthConfig(conf, ctx, respChannel, nil, nil)
 	})
 }
 
-func (authContext *AuthContext) evaluateIdentityConfigs() error {
-	configs := authContext.API.IdentityConfigs
+func (pipeline *AuthPipeline) evaluateIdentityConfigs() error {
+	configs := pipeline.API.IdentityConfigs
 	respChannel := make(chan EvaluationResponse, len(configs))
 
 	go func() {
 		defer close(respChannel)
-		authContext.evaluateOneAuthConfig(configs, &respChannel)
+		pipeline.evaluateOneAuthConfig(configs, &respChannel)
 	}()
 
 	var lastError error
@@ -135,7 +133,7 @@ func (authContext *AuthContext) evaluateIdentityConfigs() error {
 		obj := resp.Object
 
 		if resp.Success() {
-			authContext.Identity[conf] = obj
+			pipeline.Identity[conf] = obj
 			authCtxLog.Info("Identity", "config", conf, "authObj", obj)
 			return nil
 		} else {
@@ -147,13 +145,13 @@ func (authContext *AuthContext) evaluateIdentityConfigs() error {
 	return lastError
 }
 
-func (authContext *AuthContext) evaluateMetadataConfigs() {
-	configs := authContext.API.MetadataConfigs
+func (pipeline *AuthPipeline) evaluateMetadataConfigs() {
+	configs := pipeline.API.MetadataConfigs
 	respChannel := make(chan EvaluationResponse, len(configs))
 
 	go func() {
 		defer close(respChannel)
-		authContext.evaluateAnyAuthConfig(configs, &respChannel)
+		pipeline.evaluateAnyAuthConfig(configs, &respChannel)
 	}()
 
 	for resp := range respChannel {
@@ -161,7 +159,7 @@ func (authContext *AuthContext) evaluateMetadataConfigs() {
 		obj := resp.Object
 
 		if resp.Success() {
-			authContext.Metadata[conf] = obj
+			pipeline.Metadata[conf] = obj
 			authCtxLog.Info("Metadata", "config", conf, "authObj", obj)
 		} else {
 			authCtxLog.Info("Metadata", "config", conf, "error", resp.Error)
@@ -169,13 +167,13 @@ func (authContext *AuthContext) evaluateMetadataConfigs() {
 	}
 }
 
-func (authContext *AuthContext) evaluateAuthorizationConfigs() error {
-	configs := authContext.API.AuthorizationConfigs
+func (pipeline *AuthPipeline) evaluateAuthorizationConfigs() error {
+	configs := pipeline.API.AuthorizationConfigs
 	respChannel := make(chan EvaluationResponse, len(configs))
 
 	go func() {
 		defer close(respChannel)
-		authContext.evaluateAllAuthConfigs(configs, &respChannel)
+		pipeline.evaluateAllAuthConfigs(configs, &respChannel)
 	}()
 
 	for resp := range respChannel {
@@ -183,7 +181,7 @@ func (authContext *AuthContext) evaluateAuthorizationConfigs() error {
 		obj := resp.Object
 
 		if resp.Success() {
-			authContext.Authorization[conf] = obj
+			pipeline.Authorization[conf] = obj
 			authCtxLog.Info("Authorization", "config", conf, "authObj", obj)
 		} else {
 			err := resp.Error
@@ -196,41 +194,41 @@ func (authContext *AuthContext) evaluateAuthorizationConfigs() error {
 }
 
 // Evaluate evaluates all steps of the auth pipeline (identity → metadata → policy enforcement)
-func (authContext *AuthContext) Evaluate() error {
+func (pipeline *AuthPipeline) Evaluate() error {
 	// identity
-	if err := authContext.evaluateIdentityConfigs(); err != nil {
+	if err := pipeline.evaluateIdentityConfigs(); err != nil {
 		return err
 	}
 
 	// metadata
-	authContext.evaluateMetadataConfigs()
+	pipeline.evaluateMetadataConfigs()
 
 	// policy enforcement (authorization)
-	if err := authContext.evaluateAuthorizationConfigs(); err != nil {
+	if err := pipeline.evaluateAuthorizationConfigs(); err != nil {
 		return err
 	}
 
 	return nil
 }
 
-func (authContext *AuthContext) GetParentContext() *context.Context {
-	return authContext.ParentContext
+func (pipeline *AuthPipeline) GetParentContext() *context.Context {
+	return pipeline.ParentContext
 }
 
-func (authContext *AuthContext) GetRequest() *envoy_auth.CheckRequest {
-	return authContext.Request
+func (pipeline *AuthPipeline) GetRequest() *envoy_auth.CheckRequest {
+	return pipeline.Request
 }
 
-func (authContext *AuthContext) GetHttp() *envoy_auth.AttributeContext_HttpRequest {
-	return authContext.Request.Attributes.Request.Http
+func (pipeline *AuthPipeline) GetHttp() *envoy_auth.AttributeContext_HttpRequest {
+	return pipeline.Request.Attributes.Request.Http
 }
 
-func (authContext *AuthContext) GetAPI() interface{} {
-	return authContext.API
+func (pipeline *AuthPipeline) GetAPI() interface{} {
+	return pipeline.API
 }
 
-func (authContext *AuthContext) GetResolvedIdentity() (interface{}, interface{}) {
-	for identityConfig, identityObj := range authContext.Identity {
+func (pipeline *AuthPipeline) GetResolvedIdentity() (interface{}, interface{}) {
+	for identityConfig, identityObj := range pipeline.Identity {
 		if identityObj != nil {
 			id := identityConfig
 			obj := identityObj
@@ -240,9 +238,9 @@ func (authContext *AuthContext) GetResolvedIdentity() (interface{}, interface{})
 	return nil, nil
 }
 
-func (authContext *AuthContext) GetResolvedMetadata() map[interface{}]interface{} {
+func (pipeline *AuthPipeline) GetResolvedMetadata() map[interface{}]interface{} {
 	m := make(map[interface{}]interface{})
-	for metadataCfg, metadataObj := range authContext.Metadata {
+	for metadataCfg, metadataObj := range pipeline.Metadata {
 		if metadataObj != nil {
 			m[metadataCfg] = metadataObj
 		}
@@ -250,12 +248,12 @@ func (authContext *AuthContext) GetResolvedMetadata() map[interface{}]interface{
 	return m
 }
 
-func (authContext *AuthContext) GetDataForAuthorization() interface{} {
+func (pipeline *AuthPipeline) GetDataForAuthorization() interface{} {
 	authData := make(map[string]interface{})
-	_, authData["identity"] = authContext.GetResolvedIdentity()
+	_, authData["identity"] = pipeline.GetResolvedIdentity()
 
 	resolvedMetadata := make(map[string]interface{})
-	for config, obj := range authContext.GetResolvedMetadata() {
+	for config, obj := range pipeline.GetResolvedMetadata() {
 		metadataConfig, _ := config.(common.NamedConfigEvaluator)
 		resolvedMetadata[metadataConfig.GetName()] = obj
 	}
@@ -267,7 +265,7 @@ func (authContext *AuthContext) GetDataForAuthorization() interface{} {
 	}
 
 	return &authorizationData{
-		Context:  authContext.GetRequest().Attributes,
+		Context:  pipeline.GetRequest().Attributes,
 		AuthData: authData,
 	}
 }


### PR DESCRIPTION
So there is no confusion with Golang's context.