### PR TITLE
401 Unauthorized

### DIFF
--- a/pkg/common/auth.go
+++ b/pkg/common/auth.go
@@ -3,6 +3,8 @@ package common
 import (
 	"golang.org/x/net/context"
 
+	"github.com/3scale-labs/authorino/pkg/common/auth_credentials"
+
 	envoy_auth "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -28,6 +30,7 @@ type NamedConfigEvaluator interface {
 }
 
 type IdentityConfigEvaluator interface {
+	GetAuthCredentials() auth_credentials.AuthCredentials
 	GetOIDC() interface{}
 }
 

--- a/pkg/common/auth_credentials/auth_credentials.go
+++ b/pkg/common/auth_credentials/auth_credentials.go
@@ -12,6 +12,7 @@ import (
 // AuthCredentials interface represents the methods needed to fetch credentials from input
 type AuthCredentials interface {
 	GetCredentialsFromReq(*envoyServiceAuthV3.AttributeContext_HttpRequest) (string, error)
+	GetCredentialsKeySelector() string
 }
 
 // AuthCredential struct implements the AuthCredentials interface
@@ -70,6 +71,10 @@ func (c *AuthCredential) GetCredentialsFromReq(httpReq *envoyServiceAuthV3.Attri
 	default:
 		return "", fmt.Errorf(credentialLocationNotSupportedMsg)
 	}
+}
+
+func (c *AuthCredential) GetCredentialsKeySelector() string {
+	return c.KeySelector
 }
 
 func getCredFromCustomHeader(headers map[string]string, keyName string) (string, error) {

--- a/pkg/common/auth_credentials/mocks/mock_auth_credentials.go
+++ b/pkg/common/auth_credentials/mocks/mock_auth_credentials.go
@@ -48,3 +48,17 @@ func (mr *MockAuthCredentialsMockRecorder) GetCredentialsFromReq(arg0 interface{
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsFromReq", reflect.TypeOf((*MockAuthCredentials)(nil).GetCredentialsFromReq), arg0)
 }
+
+// GetCredentialsKeySelector mocks base method.
+func (m *MockAuthCredentials) GetCredentialsKeySelector() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCredentialsKeySelector")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetCredentialsKeySelector indicates an expected call of GetCredentialsKeySelector.
+func (mr *MockAuthCredentialsMockRecorder) GetCredentialsKeySelector() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCredentialsKeySelector", reflect.TypeOf((*MockAuthCredentials)(nil).GetCredentialsKeySelector))
+}

--- a/pkg/common/mocks/mock_common.go
+++ b/pkg/common/mocks/mock_common.go
@@ -8,9 +8,12 @@ import (
 	reflect "reflect"
 
 	common "github.com/3scale-labs/authorino/pkg/common"
+	auth_credentials "github.com/3scale-labs/authorino/pkg/common/auth_credentials"
 	envoy_service_auth_v3 "github.com/envoyproxy/go-control-plane/envoy/service/auth/v3"
 	gomock "github.com/golang/mock/gomock"
 	context "golang.org/x/net/context"
+	v1 "k8s.io/api/core/v1"
+	types "k8s.io/apimachinery/pkg/types"
 )
 
 // MockAuthPipeline is a mock of AuthPipeline interface.
@@ -233,6 +236,20 @@ func (m *MockIdentityConfigEvaluator) EXPECT() *MockIdentityConfigEvaluatorMockR
 	return m.recorder
 }
 
+// GetAuthCredentials mocks base method.
+func (m *MockIdentityConfigEvaluator) GetAuthCredentials() auth_credentials.AuthCredentials {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAuthCredentials")
+	ret0, _ := ret[0].(auth_credentials.AuthCredentials)
+	return ret0
+}
+
+// GetAuthCredentials indicates an expected call of GetAuthCredentials.
+func (mr *MockIdentityConfigEvaluatorMockRecorder) GetAuthCredentials() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAuthCredentials", reflect.TypeOf((*MockIdentityConfigEvaluator)(nil).GetAuthCredentials))
+}
+
 // GetOIDC mocks base method.
 func (m *MockIdentityConfigEvaluator) GetOIDC() interface{} {
 	m.ctrl.T.Helper()
@@ -245,4 +262,41 @@ func (m *MockIdentityConfigEvaluator) GetOIDC() interface{} {
 func (mr *MockIdentityConfigEvaluatorMockRecorder) GetOIDC() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOIDC", reflect.TypeOf((*MockIdentityConfigEvaluator)(nil).GetOIDC))
+}
+
+// MockAPIKeySecretFinder is a mock of APIKeySecretFinder interface.
+type MockAPIKeySecretFinder struct {
+	ctrl     *gomock.Controller
+	recorder *MockAPIKeySecretFinderMockRecorder
+}
+
+// MockAPIKeySecretFinderMockRecorder is the mock recorder for MockAPIKeySecretFinder.
+type MockAPIKeySecretFinderMockRecorder struct {
+	mock *MockAPIKeySecretFinder
+}
+
+// NewMockAPIKeySecretFinder creates a new mock instance.
+func NewMockAPIKeySecretFinder(ctrl *gomock.Controller) *MockAPIKeySecretFinder {
+	mock := &MockAPIKeySecretFinder{ctrl: ctrl}
+	mock.recorder = &MockAPIKeySecretFinderMockRecorder{mock}
+	return mock
+}
+
+// EXPECT returns an object that allows the caller to indicate expected use.
+func (m *MockAPIKeySecretFinder) EXPECT() *MockAPIKeySecretFinderMockRecorder {
+	return m.recorder
+}
+
+// FindSecretByName mocks base method.
+func (m *MockAPIKeySecretFinder) FindSecretByName(arg0 types.NamespacedName) *v1.Secret {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "FindSecretByName", arg0)
+	ret0, _ := ret[0].(*v1.Secret)
+	return ret0
+}
+
+// FindSecretByName indicates an expected call of FindSecretByName.
+func (mr *MockAPIKeySecretFinderMockRecorder) FindSecretByName(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "FindSecretByName", reflect.TypeOf((*MockAPIKeySecretFinder)(nil).FindSecretByName), arg0)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,10 @@
 package config
 
-import "github.com/3scale-labs/authorino/pkg/common"
+import (
+	"fmt"
+
+	"github.com/3scale-labs/authorino/pkg/common"
+)
 
 // APIConfig holds the static configuration to be evaluated in the auth pipeline
 type APIConfig struct {
@@ -12,10 +16,10 @@ type APIConfig struct {
 func (config *APIConfig) GetChallengeHeaders() []map[string]string {
 	challengeHeaders := make([]map[string]string, 0)
 
-	for _, idConfig := range config.IdentityConfigs {
-		idEvaluator := idConfig.(common.IdentityConfigEvaluator)
-		creds := idEvaluator.GetAuthCredentials()
-		challengeHeaders = append(challengeHeaders, map[string]string{"WWW-Authenticate": creds.GetCredentialsKeySelector()})
+	for _, authConfig := range config.IdentityConfigs {
+		idConfig := authConfig.(*IdentityConfig)
+		challenge := fmt.Sprintf("%v realm=\"%v\"", idConfig.GetAuthCredentials().GetCredentialsKeySelector(), idConfig.Name)
+		challengeHeaders = append(challengeHeaders, map[string]string{"WWW-Authenticate": challenge})
 	}
 
 	return challengeHeaders

--- a/pkg/config/identity/api_key.go
+++ b/pkg/config/identity/api_key.go
@@ -21,12 +21,6 @@ const (
 	credentialsFetchingErrorMsg = "Something went wrong fetching the authorized credentials"
 )
 
-// APIKeyIdentityEvaluator interface represents the API Key Identity evaluator
-type APIKeyIdentityEvaluator interface {
-	GetCredentialsFromCluster(context.Context) error
-	Call(common.AuthPipeline, context.Context) (interface{}, error)
-}
-
 type apiKeyDetails struct {
 	Name                  string            `yaml:"name"`
 	LabelSelectors        map[string]string `yaml:"labelSelectors"`
@@ -34,9 +28,9 @@ type apiKeyDetails struct {
 	authorizedCredentials map[string]v1.Secret
 }
 
-// APIKey struct implements the APIKeyIdentityEvaluator interface
 type APIKey struct {
 	auth_credentials.AuthCredentials
+
 	apiKeyDetails
 }
 

--- a/pkg/config/identity/hmac.go
+++ b/pkg/config/identity/hmac.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	"github.com/3scale-labs/authorino/pkg/common"
+	"github.com/3scale-labs/authorino/pkg/common/auth_credentials"
 )
 
 type HMAC struct {
+	auth_credentials.AuthCredentials
+
 	Secret string `yaml:"secret"`
 }
 

--- a/pkg/config/identity/mtls.go
+++ b/pkg/config/identity/mtls.go
@@ -4,9 +4,12 @@ import (
 	"context"
 
 	"github.com/3scale-labs/authorino/pkg/common"
+	"github.com/3scale-labs/authorino/pkg/common/auth_credentials"
 )
 
 type MTLS struct {
+	auth_credentials.AuthCredentials
+
 	PEM string `yaml:"pem"`
 }
 

--- a/pkg/config/identity/oauth2.go
+++ b/pkg/config/identity/oauth2.go
@@ -12,12 +12,12 @@ import (
 )
 
 type OAuth2 struct {
+	auth_credentials.AuthCredentials
+
 	TokenIntrospectionUrl string `yaml:"tokenIntrospectionUrl"`
 	TokenTypeHint         string `yaml:"tokenTypeHint,omitempty"`
 	ClientID              string `yaml:"clientId"`
 	ClientSecret          string `yaml:"clientSecret"`
-
-	Credentials auth_credentials.AuthCredentials
 }
 
 func NewOAuth2Identity(tokenIntrospectionUrl string, tokenTypeHint string, clientID string, clientSecret string, creds auth_credentials.AuthCredentials) *OAuth2 {
@@ -29,11 +29,11 @@ func NewOAuth2Identity(tokenIntrospectionUrl string, tokenTypeHint string, clien
 	}
 
 	return &OAuth2{
+		creds,
 		tokenIntrospectionUrl,
 		tokenHint,
 		clientID,
 		clientSecret,
-		creds,
 	}
 }
 
@@ -43,7 +43,7 @@ func (oauth *OAuth2) Call(pipeline common.AuthPipeline, ctx context.Context) (in
 	}
 
 	// retrieve access token
-	accessToken, err := oauth.Credentials.GetCredentialsFromReq(pipeline.GetHttp())
+	accessToken, err := oauth.GetCredentialsFromReq(pipeline.GetHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/identity/oidc.go
+++ b/pkg/config/identity/oidc.go
@@ -11,8 +11,9 @@ import (
 )
 
 type OIDC struct {
-	Endpoint    string `yaml:"endpoint"`
-	Credentials auth_credentials.AuthCredentials
+	auth_credentials.AuthCredentials
+
+	Endpoint string `yaml:"endpoint"`
 
 	provider *goidc.Provider
 }
@@ -22,8 +23,8 @@ func NewOIDC(endpoint string, creds auth_credentials.AuthCredentials) (*OIDC, er
 		return nil, err
 	} else {
 		return &OIDC{
-			endpoint,
 			creds,
+			endpoint,
 			issuer,
 		}, nil
 	}
@@ -31,7 +32,7 @@ func NewOIDC(endpoint string, creds auth_credentials.AuthCredentials) (*OIDC, er
 
 func (oidc *OIDC) Call(pipeline common.AuthPipeline, ctx context.Context) (interface{}, error) {
 	// retrieve access token
-	accessToken, err := oidc.Credentials.GetCredentialsFromReq(pipeline.GetRequest().GetAttributes().GetRequest().GetHttp())
+	accessToken, err := oidc.GetCredentialsFromReq(pipeline.GetRequest().GetAttributes().GetRequest().GetHttp())
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/config/metadata/user_info.go
+++ b/pkg/config/metadata/user_info.go
@@ -25,7 +25,7 @@ func (userinfo *UserInfo) Call(pipeline common.AuthPipeline, ctx context.Context
 	}
 
 	// get access token from input
-	accessToken, err := oidc.Credentials.GetCredentialsFromReq(pipeline.GetHttp())
+	accessToken, err := oidc.GetCredentialsFromReq(pipeline.GetHttp())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Implements `401 Unauthorized` HTTP response code when all identity sources fail to evaluate the supplied credentials, instead of the currently returned status `403 Forbidden`.

The implementation complies with [RFC 7235](https://tools.ietf.org/html/rfc7235), adding as well the challenge response headers `WWW-Authenticate`. The `<type>` of each challenge is set with the key selector of the corresponding credentials config and the `realm` info to the name of the identity source. Moreover, instead of a comma-separated list of challenges inside of a single `WWW-Authenticate` header, multiple headers are added to the response (see subsection 4.1 of the RFC). E.g.:

```
< HTTP/1.1 401 Unauthorized
< www-authenticate: Bearer realm="auth-server"
< www-authenticate: APIKEY realm="friends"
```

The value of the HTTP response header `x-ext-auth-reason` will now expand to a JSON when more than one identity source is present and they all fail. E.g.:

```
< x-ext-auth-reason: {"auth-server": "Not authenticated", "friends": "invalid API key"}
```


To better accomodate a fetcher for the auth credentials at the level of te identity config, the PR refactors the implementation of the `common.AuthCredentials` interface by the identity evaluators.